### PR TITLE
Two bugfixes.

### DIFF
--- a/scribble-doc/scribblings/scribble/text.scrbl
+++ b/scribble-doc/scribblings/scribble/text.scrbl
@@ -1239,7 +1239,7 @@ Outputs values to @racket[port] as follows for each kind of @racket[v]:
          @tech/r{characters}: converts the value to a string along the
          same lines as @racket[display], and then passes the string to
          the @deftech{current writer}, which is initially
-         @racket[display]}
+         @racket[write-string]}
 
    @item{@|void-const|, @racket[#f], or @racket[null]: no output}
 

--- a/scribble-text-lib/scribble/text/output.rkt
+++ b/scribble-text-lib/scribble/text/output.rkt
@@ -273,7 +273,7 @@
 (define/provide-special (restore-prefix))
 (define/provide-special (add-prefix [pfx (or/c string? exact-nonnegative-integer?)]))
 (define/provide-special (set-prefix [pfx (or/c string? exact-nonnegative-integer?)]))
-(define/provide-special (with-writer [writer (or/c #f (->* (string? output-port?) (exact-nonnegative-integer?) any/c))]))
+(define/provide-special (with-writer [writer (or/c #f (->* (string? output-port?) (exact-nonnegative-integer? exact-nonnegative-integer?) any/c))]))
 #; ; no need for this hack yet
 (define/provide-special (with-writer-change writer))
 


### PR DESCRIPTION
* Fix contract on `with-writer`.

* The default writer is initially `write-string`, not `display`.