### PR TITLE
Make code rendering more robust to missing location information.

### DIFF
--- a/scribble-lib/scribble/private/manual-code.rkt
+++ b/scribble-lib/scribble/private/manual-code.rkt
@@ -141,7 +141,8 @@
            [ids (let loop ([e e])
                   (cond
                    [(and (identifier? e)
-                         (syntax-original? e))
+                         (syntax-original? e)
+                         (syntax-position e))
                     (let ([pos (sub1 (syntax-position e))])
                       (list (list (lambda (str)
                                     (to-element (syntax-property


### PR DESCRIPTION
Before this change, the `profj` docs errored with the following error
```
raco setup: 2 running: <pkgs>/profj/profj/scribblings/profj.scrbl
sub1: contract violation
  expected: number?
  given: #f
  context...:
   /Users/stamourv/src/plt/extra-pkgs/scribble/scribble-lib/scribble/private/manual-code.rkt:141:16: loop
...
```

This change fixes this problem, doesn't break the tests, and didn't break code rendering in the few other documents I checked. I'm not super familiar with the Scribble codebase, though, so there may be something I missed.