### PR TITLE
Add /Library/TeX/texbin as another candidate-dir

### DIFF
--- a/scribble-lib/scribble/private/run-pdflatex.rkt
+++ b/scribble-lib/scribble/private/run-pdflatex.rkt
@@ -92,4 +92,4 @@
 ;; here so that the "scribble pdf" button is more 
 ;; likely to work in drracket
 (define macosx-candidate-dirs
-  '("/usr/texbin"))
+  '("/usr/texbin" "/Library/TeX/texbin"))


### PR DESCRIPTION
MacTeX, TeX for Mac, will install the binaries at `/Library/TeX/texbin`. Hence, we should add this path to the candidate-dirs.