### PR TITLE
scribble/jfp: affiliation-mark example

### DIFF
--- a/scribble-doc/scribblings/scribble/jfp.scrbl
+++ b/scribble-doc/scribblings/scribble/jfp.scrbl
@@ -55,3 +55,19 @@ If different authors have different affiliations, use
 use @racket[affiliation-mark] before each different affiliation within
 a single @racket[affiliation], using @racket[(affiliation-sep)] to
 separate affiliations.}
+
+Examples:
+@codeblock|{
+#lang scribble/jfp
+
+@title{My First Love Story}
+
+@((author/short "Romeo M. and Juliet C.")
+  "ROMEO" (affiliation-mark "1")
+  " and "
+  "JULIET" (affiliation-mark "2")
+  @affiliation[
+    "House Montague" (affiliation-mark "1")
+    (affiliation-sep)
+    "House Capulet" (affiliation-mark "2")])
+}|


### PR DESCRIPTION
Small example using `author/short` with affiliations.

- Is there a better way to write this? I don't like the space before `"and"` on [line 63](https://github.com/racket/scribble/compare/master...bennn:affiliation-example?expand=1#diff-1c5234a2c4169b9cf9aec5e47350c27eR63)
- Is there a way to render this in the reference manual? `doc-render-examples` is not quite right; should I add a screenshot?