### PR TITLE
Provide the special struct

### DIFF
--- a/scribble-text-lib/scribble/text/output.rkt
+++ b/scribble-text-lib/scribble/text/output.rkt
@@ -250,6 +250,7 @@
 
 ;; special constructs
 
+(provide (struct-out special))
 (define-struct special (flag contents))
 
 (define-syntax define/provide-special


### PR DESCRIPTION
In order to write a converter from html expression represented using `element` and `special` into SXML the struct `special` needs to be provided.
