### PR TITLE
Add language-index-desc struct, subtype of module-path-index-desc

### DIFF
--- a/scribble-doc/scribblings/scribble/manual.scrbl
+++ b/scribble-doc/scribblings/scribble/manual.scrbl
@@ -2049,6 +2049,11 @@ rendered document.}
 Indicates that the index entry corresponds to a module definition via
 @racket[defmodule] and company.}
 
+@defstruct[(language-index-desc module-path-index-desc) ()]{
+
+Indicates that the index entry corresponds to a module definition via
+@racket[defmodulelang], etc.}
+
 @defstruct[exported-index-desc ([name symbol?]
                                [from-libs (listof module-path?)])]{
 

--- a/scribble-lib/scribble/manual-struct.rkt
+++ b/scribble-lib/scribble/manual-struct.rkt
@@ -5,6 +5,7 @@
 
 (provide-structs
  [module-path-index-desc ()]
+ [(language-index-desc module-path-index-desc) ()]
  [exported-index-desc ([name symbol?]
                        [from-libs (listof module-path?)])]
  [(method-index-desc exported-index-desc) ([method-name symbol?]

--- a/scribble-lib/scribble/private/manual-mod.rkt
+++ b/scribble-lib/scribble/private/manual-mod.rkt
@@ -224,7 +224,7 @@
       (map
        (lambda (name modpath)
          (define modname (if link-target?
-                             (make-defracketmodname name modpath)
+                             (make-defracketmodname name modpath (and lang #t))
                              name))
          (list
           (make-flow
@@ -278,8 +278,9 @@
               (flow-paragraphs (decode-flow content)))))))
 
 (define the-module-path-index-desc (make-module-path-index-desc))
+(define the-language-index-desc (make-language-index-desc))
 
-(define (make-defracketmodname mn mp)
+(define (make-defracketmodname mn mp [lang? #f])
   (let ([name-str (datum-intern-literal (element->string mn))]
         [path-str (datum-intern-literal (element->string mp))])
     (make-index-element #f
@@ -287,7 +288,9 @@
                         (intern-taglet `(mod-path ,path-str))
                         (list name-str)
                         (list mn)
-                        the-module-path-index-desc)))
+                        (if lang?
+                            the-language-index-desc
+                            the-module-path-index-desc))))
 
 (define-syntax (declare-exporting stx)
   (syntax-parse stx


### PR DESCRIPTION
Used to tell if a module implements a `#lang` or reader.
Required by https://github.com/racket/racket/pull/1355