### PR TITLE
Add reader-index-desc struct

### DIFF
--- a/scribble-doc/scribblings/scribble/manual.scrbl
+++ b/scribble-doc/scribblings/scribble/manual.scrbl
@@ -2049,6 +2049,11 @@ rendered document.}
 Indicates that the index entry corresponds to a module definition via
 @racket[defmodule] and company.}
 
+@defstruct[(language-index-desc module-path-index-desc) ()]{
+
+Indicates that the index entry corresponds to a module definition via
+@racket[defmodulelang], etc.}
+
 @defstruct[exported-index-desc ([name symbol?]
                                [from-libs (listof module-path?)])]{
 

--- a/scribble-doc/scribblings/scribble/manual.scrbl
+++ b/scribble-doc/scribblings/scribble/manual.scrbl
@@ -2049,10 +2049,15 @@ rendered document.}
 Indicates that the index entry corresponds to a module definition via
 @racket[defmodule] and company.}
 
-@defstruct[(language-index-desc module-path-index-desc) ()]{
-
+@deftogether[(
+@defstruct[(language-index-desc module-path-index-desc)]{}
+@defstruct[(reader-index-desc module-path-index-desc)]{}
+)]{
 Indicates that the index entry corresponds to a module definition via
-@racket[defmodulelang], etc.}
+@racket[defmodule] with the @racket[#:lang] or @racket[#:reader] option.
+For example, a module definition via @racket[defmodulelang] has a
+@racket[language-index-desc] index entry and a module definition via
+@racket[defmodulereader] has a @racket[reader-index-desc] index entry.}
 
 @defstruct[exported-index-desc ([name symbol?]
                                [from-libs (listof module-path?)])]{

--- a/scribble-lib/scribble/manual-struct.rkt
+++ b/scribble-lib/scribble/manual-struct.rkt
@@ -6,6 +6,7 @@
 (provide-structs
  [module-path-index-desc ()]
  [(language-index-desc module-path-index-desc) ()]
+ [(reader-index-desc module-path-index-desc) ()]
  [exported-index-desc ([name symbol?]
                        [from-libs (listof module-path?)])]
  [(method-index-desc exported-index-desc) ([method-name symbol?]

--- a/scribble-lib/scribble/manual-struct.rkt
+++ b/scribble-lib/scribble/manual-struct.rkt
@@ -5,6 +5,7 @@
 
 (provide-structs
  [module-path-index-desc ()]
+ [(language-index-desc module-path-index-desc) ()]
  [exported-index-desc ([name symbol?]
                        [from-libs (listof module-path?)])]
  [(method-index-desc exported-index-desc) ([method-name symbol?]

--- a/scribble-lib/scribble/private/manual-mod.rkt
+++ b/scribble-lib/scribble/private/manual-mod.rkt
@@ -224,7 +224,7 @@
       (map
        (lambda (name modpath)
          (define modname (if link-target?
-                             (make-defracketmodname name modpath)
+                             (make-defracketmodname name modpath (and lang #t))
                              name))
          (list
           (make-flow
@@ -278,8 +278,9 @@
               (flow-paragraphs (decode-flow content)))))))
 
 (define the-module-path-index-desc (make-module-path-index-desc))
+(define the-language-index-desc (make-language-index-desc))
 
-(define (make-defracketmodname mn mp)
+(define (make-defracketmodname mn mp [lang? #f])
   (let ([name-str (datum-intern-literal (element->string mn))]
         [path-str (datum-intern-literal (element->string mp))])
     (make-index-element #f
@@ -287,7 +288,9 @@
                         (intern-taglet `(mod-path ,path-str))
                         (list name-str)
                         (list mn)
-                        the-module-path-index-desc)))
+                        (if lang?
+                            the-language-index-desc
+                            the-module-path-index-desc))))
 
 (define-syntax (declare-exporting stx)
   (syntax-parse stx


### PR DESCRIPTION
Thanks to @AlexKnauth for pointing out that `#reader` modules should not appear if a user searches for `#lang` modules.

This PR adds a new index description for reader modules. Also changes where `manual-mod.rkt` branches on its `lang` argument, to keep that case statement in 1 place.