### PR TITLE
use xcolor package (instead of color)

### DIFF
--- a/scribble-lib/scribble/scribble-load.tex
+++ b/scribble-lib/scribble/scribble-load.tex
@@ -11,7 +11,7 @@
 \newcommand{\packageTextcomp}{\usepackage{textcomp}}
 \newcommand{\packageFramed}{\usepackage{framed}}
 \newcommand{\packageHyphenat}{\usepackage[htt]{hyphenat}}
-\newcommand{\packageColor}{\usepackage[usenames,dvipsnames]{color}}
+\newcommand{\packageColor}{\usepackage[usenames,dvipsnames]{xcolor}}
 \newcommand{\doHypersetup}{\hypersetup{bookmarks=true,bookmarksopen=true,bookmarksnumbered=true}}
 \newcommand{\packageTocstyle}{\IfFileExists{tocstyle.sty}{\usepackage{tocstyle}\usetocstyle{standard}}{}}
 \newcommand{\packageCJK}{\IfFileExists{CJK.sty}{\usepackage{CJK}}{}}


### PR DESCRIPTION
`0.` There's already a fix ([`latex-defaults+replacements`](http://docs.racket-lang.org/scribble/core.html#%28def._%28%28lib._scribble%2Flatex-properties..rkt%29._latex-defaults%2Breplacements%29%29)) for my problem, so we can close this if there's any question. But,

afaikt, the [xcolor](https://www.ctan.org/pkg/xcolor?lang=en) package is an improvement over the [color](https://www.ctan.org/pkg/color?lang=en) package:
- provides "basic facilities of `color`" (according to the docs)
- other packages e.g. `tikz` load `xcolor` anyway; when this happens you might get pages of "incompatible color definition on line N" like I've been getting
