### PR TITLE
update scribble/html tags, add scribble/html/extra

### DIFF
--- a/scribble-doc/scribblings/scribble/html.scrbl
+++ b/scribble-doc/scribblings/scribble/html.scrbl
@@ -94,6 +94,7 @@ as XHTML.
   style ; style info, which may include CDATA sections
   script ; script statements, which may include CDATA sections
   noscript ; alternate content container for non script-based rendering
+  slot
   frameset ; only one noframes element permitted per document
   frame ; tiled window within frameset
   iframe ; inline subwindow
@@ -107,6 +108,7 @@ as XHTML.
   h4
   h5
   h6
+  hgroup
   ul ; Unordered list
   ol ; Ordered (numbered) list
   menu ; single column list (DEPRECATED)
@@ -165,7 +167,10 @@ as XHTML.
   colgroup ; column group, olds col
   tr ; holds th or td
   th ; header cell
-  td)
+  td
+  details
+  dialog
+  menuitem)
 
 @(define-syntax-rule (def-tags/empty tag ...)
    @deftogether[(
@@ -179,7 +184,8 @@ as XHTML.
     (output-xml (hr))]})
 
 @(def-tags/empty
-  base meta link hr br basefont param img area input isindex col)
+  base meta link hr br basefont param img area input isindex col
+  embed keygen wbr)
 
 @(define-syntax-rule (def-entities ent ...)
    @deftogether[(
@@ -211,6 +217,52 @@ Procedures a value that renders as an inline style sheet.
 @examples[#:eval html-eval
 (output-xml (style/inline type: "text/css"
                           ".racket { font-size: xx-large; }"))]}
+
+
+@subsection[#:tag "extra-html"]{Other HTML elements}
+
+@defmodule[scribble/html/extra]
+
+Provides renderers for
+@hyperlink["https://html.spec.whatwg.org/multipage/#toc-semantics"]{HTML
+elements} that are not provided by @racket[scribble/html/html].
+
+@(def-tags
+  article
+  aside
+  audio
+  bdi
+  canvas
+  data
+  datalist
+  figcaption
+  figure
+  footer
+  header
+  main
+  map
+  mark
+  math
+  meter
+  nav
+  output
+  picture
+  progress
+  rb
+  rp
+  rt
+  rtc
+  ruby
+  section
+  summary
+  svg
+  template
+  time
+  video)
+
+@(def-tags/empty
+  source
+  track)
 
 
 @; ----------------------------------------

--- a/scribble-html-lib/scribble/html.rkt
+++ b/scribble-html-lib/scribble/html.rkt
@@ -2,3 +2,171 @@
 
 (require "html/main.rkt")
 (provide (all-from-out "html/main.rkt"))
+
+(module test racket/base
+
+  ;; Check that the HTML tags provided by scribble/html/html
+  ;;  and scribble/html/extra
+  ;;  match a master list of HTML tags (defined in this file)
+  ;; Also check that `scribble/html/html` is disjoint from `racket/base`
+
+  (require rackunit racket/set)
+
+  (define (phase0-provides m) ; Symbol -> [Setof Symbol]
+    (parameterize ([current-namespace (make-base-namespace)])
+      (dynamic-require m #f)
+      (let-values ([(e1* e2*) (module->exports m)])
+        (for*/seteq ([export* (in-list (list e1* e2*))]
+                     [tag+exp (in-list export*)]
+                     #:when (or (not (car tag+exp)) (zero? (car tag+exp)))
+                     [exp (in-list (cdr tag+exp))])
+          (car exp)))))
+
+  (define (expected-disjoint m1 m2)
+    (format "'~a' and '~a' should provide disjoint sets of identifiers" m1 m2))
+
+  (define (expected-overlap m1 m2)
+    (format "expected '~a' and '~a' to provide overlapping sets of identifiers" m1 m2))
+
+  (define html-provides (phase0-provides 'scribble/html/html))
+  (define extra-provides (phase0-provides 'scribble/html/extra))
+  (define base-provides (phase0-provides 'racket/base))
+
+  (check-pred set-empty?
+              (set-intersect html-provides extra-provides)
+              (expected-disjoint 'scribble/html/html 'scribble/html/extra))
+
+  ;; note: 'racket' and 'scribble/html/html' both provide "link"
+  (check-pred set-empty?
+              (set-intersect html-provides base-provides)
+              (expected-disjoint 'scribble/html/html 'racket/base))
+
+  (check-pred positive?
+              (set-count (set-intersect extra-provides base-provides))
+              (expected-overlap 'scribble/html/extra 'racket/base))
+
+  ;; From: https://html.spec.whatwg.org/multipage/#toc-semantics
+  (define whatwg-master (list->seteq '(
+    html
+    head
+    title
+    base
+    link
+    meta
+    style
+    body
+    article
+    section
+    nav
+    aside
+    h1 h2 h3 h4 h5 h6
+    hgroup
+    header
+    footer
+    address
+    p
+    hr
+    pre
+    blockquote
+    ol
+    ul
+    li
+    dl
+    dt
+    dd
+    figure
+    figcaption
+    main
+    div
+    a
+    em
+    strong
+    small
+    s
+    cite
+    q
+    dfn
+    abbr
+    ruby
+    rt
+    rp
+    data
+    time
+    code
+    var
+    samp
+    kbd
+    sub sup
+    i
+    b
+    u
+    mark
+    bdi
+    bdo
+    span
+    br
+    wbr
+    ins
+    del
+    picture
+    source
+    img
+    iframe
+    embed
+    object
+    param
+    video
+    audio
+    track
+    map
+    area
+    table
+    caption
+    colgroup
+    col
+    tbody
+    thead
+    tfoot
+    tr
+    td
+    th
+    form
+    label
+    input
+    button
+    select
+    datalist
+    optgroup
+    option
+    textarea
+    keygen
+    output
+    progress
+    meter
+    fieldset
+    legend
+    details
+    summary
+    menu
+    menuitem
+    dialog
+    script
+    noscript
+    template
+    slot
+    canvas)))
+
+  (let ([scribble-master (set-union html-provides extra-provides)])
+    (check-true (subset? whatwg-master scribble-master))
+    ;; Uncomment to debug scribble provides vs. whatwg master
+    #;(void
+      (displayln "checking MASTER vs SCRIBBLE")
+      (for ([m (in-set whatwg-master)]
+            #:when (not (set-member? scribble-master m)))
+        (displayln m))
+      (newline)
+      (displayln "checking SCRIBBLE vs MASTER")
+      (for ([s (in-set scribble-master)]
+            #:when (not (set-member? whatwg-master s)))
+        (displayln s))))
+)

--- a/scribble-html-lib/scribble/html/extra.rkt
+++ b/scribble-html-lib/scribble/html/extra.rkt
@@ -1,0 +1,42 @@
+#lang racket/base
+
+;; (X)HTML elements that are uncommon / likely to cause namespace conflicts
+
+(require "xml.rkt")
+
+(define/provide-elements/empty
+  source
+  track)
+
+(define/provide-elements/not-empty
+  article
+  aside
+  audio
+  bdi
+  canvas
+  data
+  datalist
+  figcaption
+  figure
+  footer
+  header
+  main
+  map
+  mark
+  math
+  meter
+  nav
+  output
+  picture
+  progress
+  rb
+  rp
+  rt
+  rtc
+  ruby
+  section
+  summary
+  svg
+  template
+  time
+  video)

--- a/scribble-html-lib/scribble/html/html.rkt
+++ b/scribble-html-lib/scribble/html/html.rkt
@@ -1,6 +1,9 @@
 #lang racket/base
 
 ;; (X)HTML elements etc.
+;; Keep this file up to date with:
+;;    https://html.spec.whatwg.org/multipage/#toc-semantics
+;; Put esoteric elements in scribble/html/extra
 
 (require "xml.rkt" scribble/text)
 
@@ -59,6 +62,7 @@
   style ; style info, which may include CDATA sections
   script ; script statements, which may include CDATA sections
   noscript ; alternate content container for non script-based rendering
+  slot
   ;; ========== Frames
   frameset ; only one noframes element permitted per document
   frame ; tiled window within frameset
@@ -76,6 +80,7 @@
   h4
   h5
   h6
+  hgroup
   ;; ========== Lists
   ul ; Unordered list
   ol ; Ordered (numbered) list
@@ -163,11 +168,16 @@
   tr ; holds th or td
   th ; header cell
   td ; table cell
+  ;; ========== Interactive Elements
+  details
+  dialog
+  menuitem
   )
 
 ;; [*] empty elements, these are listed with an `EMPTY' content in
 ;; http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd
 (define/provide-elements/empty
+  embed keygen wbr
   base meta link hr br basefont param img area input isindex col)
 
 ;; [*] elements with a cdata/comment body


### PR DESCRIPTION
(Successor to #39 and #56)

Provide renderers for html4 and html5 elements not exported by scribble/html, from modules:
- `scribble/html/4`
- `scribble/html/5`

`html/4` only provides `map`. Everything else is already in `scribble/html/html`. I guess we could move things from there to `html/4`, then require them in `scribble/html`.

`html/5` provides everything, including the ruby tags and `svg`. Using `only-in` or `prefix-in` to avoid name clashes shouldn't be too annoying.
