### PR TITLE
Fix margin notes overlap

### DIFF
--- a/scribble-lib/scribble/manual-style.css
+++ b/scribble-lib/scribble/manual-style.css
@@ -315,7 +315,7 @@ a:hover {
 
 
 /* slightly different handling for margin-note* on narrow screens */
-@media all and (max-width:1260px) {
+@media all and (max-width:1340px) {
      span.refcolumn {
          float: right;
          width: 50%;
@@ -352,13 +352,12 @@ a:hover {
 }
 
 
-@media all and (min-width:1260px) {
+@media all and (min-width:1340px) {
     .refcolumn {
-        position: absolute;
-        left: 66rem; right: 3em;
-        margin: 0;
+        margin: 0 -22.5rem 1rem 0;
         float: right;
-        max-width: 18rem;
+        clear: right;
+        width: 18rem;
     }
 }
 


### PR DESCRIPTION
Fixes #66.

**BEFORE**

![demand-driven_program_analysis](https://cloud.githubusercontent.com/assets/586813/20323071/604ba55e-ab49-11e6-8a3d-ee105a051f66.png)

**AFTER**

![demand-driven_program_analysis](https://cloud.githubusercontent.com/assets/586813/20323055/4e41ab88-ab49-11e6-8740-58ee19a03155.png)

**GOOD SIDE-EFFECT**

Before, if the page ended on a margin-note, it had no bottom margin:

![demand-driven_program_analysis](https://cloud.githubusercontent.com/assets/586813/20323236/dd899d96-ab49-11e6-89c1-8e7177bcf753.png)

Now, it has:

![demand-driven_program_analysis](https://cloud.githubusercontent.com/assets/586813/20323261/f21c6a86-ab49-11e6-9211-61fb6b277fe7.png)

**CAVEAT**

To make this work, I had to remove the wiggle room on the margin note width. Before, it varied in size on the 1260–1340px viewport range. Now, it is fixed to always have its maximum width, which means that screens that previously would show narrower margin notes now show interspersed ones.

I don’t see a way to conciliate the two features, but it is a small price to pay for the benefit, in my opinion. Of course, you’re the ultimate judge 😀

**TESTED ON**

- Firefox 49.
- Chromium 51.
- Safari 10.

All on OS X El Capitan.