### PR TITLE
Add `meta` to Scribble template for mobile

### DIFF
--- a/scribble-lib/scribble/html-render.rkt
+++ b/scribble-lib/scribble/html-render.rkt
@@ -867,6 +867,8 @@
                  (head ()
                    (meta ([http-equiv "content-type"]
                           [content "text/html; charset=utf-8"]))
+                   (meta ([name "viewport"]
+                          [content "width=device-width, initial-scale=0.8"]))
                    ,title
                    ,(scribble-css-contents scribble-css
                                            (lookup-path scribble-css alt-paths) 


### PR DESCRIPTION
Forces the narrow (one-column) layout on mobile devices.