### PR TITLE
Handle nested collect-element inside a traverse-element

### DIFF
--- a/scribble-lib/scribble/base-render.rkt
+++ b/scribble-lib/scribble/base-render.rkt
@@ -680,6 +680,8 @@
         (begin (when (target-element? i) (collect-target-element i ci))
                (when (index-element? i) (collect-index-element i ci))
                (when (collect-element? i) ((collect-element-collect i) ci))
+               (when (traverse-element? i)
+                 (collect-content (traverse-element-content i ci) ci))
                (when (element? i)
                  (collect-content (element-content i) ci))
                (when (multiarg-element? i)


### PR DESCRIPTION
Currently, if we run:

```
(traverse-block
    (lambda (get set)
      (lambda (get set)
        (para (collect-element #f (bold (~a value))
           (lambda (ci)
              (collect-put! ci '(out some-value) value)))))))
```

The `value` will be successfully collected into `collect-info`. However, the code below would fail, without the collect lambda inside the `collect-element` being called.

```
(traverse-element
    (lambda (get set)
      (lambda (get set)
        (collect-element #f (bold (~a value))
           (lambda (ci)
              (collect-put! ci '(out some-value) value))))))
```

This pull request handles `traverse-element` in `collect-content` to fix this.