### PR TITLE
Handle Chinese Hanzi, Hiragana and Katakana in tag

### DIFF
--- a/scribble-lib/scribble/base.rkt
+++ b/scribble-lib/scribble/base.rkt
@@ -44,7 +44,7 @@
 
 (define (gen-tag content)
   (datum-intern-literal
-   (regexp-replace* "[^-a-zA-Z0-9_=]" (content->string content) "_")))
+   (regexp-replace* #px"[^-a-zA-Z0-9_=\u4e00-\u9fa5\u3040-\u309F\u30A0-\u30FF]" (content->string content) "_")))
 
 (define (prefix->string p)
   (and p (if (string? p) 

--- a/scribble-lib/scribble/base.rkt
+++ b/scribble-lib/scribble/base.rkt
@@ -44,7 +44,7 @@
 
 (define (gen-tag content)
   (datum-intern-literal
-   (regexp-replace* #px"[^-a-zA-Z0-9_=\u4e00-\u9fa5\u3040-\u309F\u30A0-\u30FF]" (content->string content) "_")))
+   (regexp-replace* "[^-a-zA-Z0-9_=\u4e00-\u9fa5\u3040-\u309F\u30A0-\u30FF]" (content->string content) "_")))
 
 (define (prefix->string p)
   (and p (if (string? p) 

--- a/scribble-lib/scribble/base.rkt
+++ b/scribble-lib/scribble/base.rkt
@@ -44,7 +44,7 @@
 
 (define (gen-tag content)
   (datum-intern-literal
-   (regexp-replace* "[^-a-zA-Z0-9_=\u4e00-\u9fa5\u3040-\u309F\u30A0-\u30FF]" (content->string content) "_")))
+   (regexp-replace* "[^-a-zA-Z0-9_=\u4e00-\u9fff\u3040-\u309F\u30A0-\u30FF]" (content->string content) "_")))
 
 (define (prefix->string p)
   (and p (if (string? p) 


### PR DESCRIPTION
Otherwise, any unicode will be replaced by "___", which results in duplicate tags.