### PR TITLE
Support hidden elements

### DIFF
--- a/scribble-lib/scribble/html-render.rkt
+++ b/scribble-lib/scribble/html-render.rkt
@@ -1592,6 +1592,7 @@
            [(smaller) '([class "Smaller"])]
            [(larger) '([class "Larger"])]
            [(hspace) '([class "hspace"])]
+           [(hidden) '([style "display: none"])]
            [(newline) '()]
            [else (error 'html-render "unrecognized style symbol: ~e" name)])]
         [(string? name) (if style null `([class ,name]))]

--- a/scribble-lib/scribble/latex-render.rkt
+++ b/scribble-lib/scribble/latex-render.rkt
@@ -452,6 +452,9 @@
                   [(superscript) (wrap e "textsuper" #f)]
                   [(smaller) (wrap e "Smaller" #f)]
                   [(larger) (wrap e "Larger" #f)]
+                  [(hidden)
+                   (check-render)
+                   (void)]
                   [(hspace)
                    (check-render)
                    (let ([s (content->string e)])

--- a/scribble-lib/scribble/markdown-render.rkt
+++ b/scribble-lib/scribble/markdown-render.rkt
@@ -227,6 +227,9 @@
           (display str)))
 
       (cond
+        [(and (element? i) (eq? (element-style i) 'hidden))
+         (super render-content "" part ri)]
+
         [(and (code? i) (not (in-code?)))
           (recurse-wrapped "`" in-code?)]
 

--- a/scribble-lib/scribble/text-render.rkt
+++ b/scribble-lib/scribble/text-render.rkt
@@ -259,14 +259,19 @@
       null)
 
     (define/override (render-content i part ri)
-      (if (and (element? i)
-               (let ([s (element-style i)])
-                 (or (eq? 'hspace s)
-                     (and (style? s)
-                          (eq? 'hspace (style-name s))))))
-          (parameterize ([current-preserve-spaces #t])
-            (super render-content i part ri))
-          (super render-content i part ri)))
+      (cond
+        [(and (element? i) (eq? (element-style i) 'hidden))
+         (super render-content "" part ri)]
+
+        [(and (element? i)
+              (let ([s (element-style i)])
+                (or (eq? 'hspace s)
+                    (and (style? s)
+                         (eq? 'hspace (style-name s))))))
+         (parameterize ([current-preserve-spaces #t])
+           (super render-content i part ri))]
+
+        [else (super render-content i part ri)]))
 
     (define/override (render-nested-flow i part ri starting-item?)
       (define s (nested-flow-style i))


### PR DESCRIPTION
Sometimes you just want an element to be completely hidden. This pull request add hidden element render support for text, markdown, latex and html through a new style tag `'hidden`.