### PR TITLE
defstruct: no newline between name & fields if no fields

### DIFF
--- a/scribble-lib/scribble/private/manual-proc.rkt
+++ b/scribble-lib/scribble/private/manual-proc.rkt
@@ -857,17 +857,16 @@
                             (short-width . < . max-proto-width))]
                        [split-field-line?
                         ;; start fields on the line after "struct"?
-                        (max-proto-width . < . (+ 8
-                                                  (if (pair? name)
-                                                      (+ (sym-length (car name))
-                                                         1
-                                                         (sym-length (cadr name)))
-                                                      (sym-length name))
-                                                  1
-                                                  (if (pair? fields)
-                                                      (sym-length (field-name (car fields)))
-                                                      0)
-                                                  1))])
+                        (and (pair? fields)
+                             (max-proto-width . < . (+ 8
+                                                       (if (pair? name)
+                                                           (+ (sym-length (car name))
+                                                              1
+                                                              (sym-length (cadr name)))
+                                                           (sym-length name))
+                                                       1
+                                                       (sym-length (field-name (car fields)))
+                                                       1)))])
                   (make-table
                    #f
                    ;; First four columns: "(struct" <space> <name><space> (

--- a/scribble-test/tests/scribble/docs/manual.scrbl
+++ b/scribble-test/tests/scribble/docs/manual.scrbl
@@ -90,6 +90,8 @@ A function, again, not a link target, documented to return @racket[10] using a d
 
 @defstruct[#:link-target? #f pt ([x real?] [y real?]) #:mutable]{A mutable structure type with extra name, again.}
 
+@defstruct[a-struct-with-an-extremely-long-name-and-no-fields ()]{Used to raise error, taking car of empty fields list. Reported by Carlos Lopez, 2017-03-11.}
+
 
 @defmodule["manual-ex0.rkt" #:no-declare #:link-target? #f #:packages ()]
 @defmodule["manual-ex0.rkt" #:lang #:no-declare #:link-target? #f #:packages ()]


### PR DESCRIPTION
If a struct has no fields, don't check if a struct's name + first field's name
are too long to print on one line

Bug report: https://groups.google.com/forum/#!topic/racket-users/6fKGky4tud8