### PR TITLE
add font size options to scribble/acmart

### DIFF
--- a/scribble-doc/scribblings/scribble/acmart.scrbl
+++ b/scribble-doc/scribblings/scribble/acmart.scrbl
@@ -44,6 +44,10 @@ all mutually exclusive.}
 @defidform[natbib]
 @defidform[anonymous]
 @defidform[authorversion]
+@defidform[9pt]
+@defidform[10pt]
+@defidform[11pt]
+@defidform[12pt]
 )]{
 
 Enables the given document format option. Use the option only on the
@@ -55,6 +59,7 @@ number of options may be used:
   #lang scribble/acmart @acmsmall @review @anonymous @natbib
 }|
 
+If multiple font size options are used, all but the last are ignored.
 }
 
 @defproc[(maketitle) block?]{

--- a/scribble-lib/scribble/acmart.rkt
+++ b/scribble-lib/scribble/acmart.rkt
@@ -76,7 +76,7 @@
 ; format options
 (defopts manuscript acmsmall acmlarge acmtog sigconf siggraph sigplan sigchi sigchi-a)
 ; boolean options
-(defopts review screen natbib anonymous authorversion)
+(defopts review screen natbib anonymous authorversion 9pt 10pt 11pt 12pt)
 
 (define acmart-extras
   (let ([abs (lambda (s)

--- a/scribble-lib/scribble/acmart/lang.rkt
+++ b/scribble-lib/scribble/acmart/lang.rkt
@@ -20,10 +20,11 @@
            [screen? #f]
            [natbib? #f]
            [anonymous? #f]
-           [authorversion? #f])
+           [authorversion? #f]
+           [font-size #f])
        (let loop ([stuff #'body])
          (syntax-case* stuff (manuscript acmsmall acmlarge acmtog sigconf siggraph sigplan sigchi sigchi-a
-					 review screen natbib anonymous authorversion)
+					 review screen natbib anonymous authorversion 9pt 10pt 11pt 12pt)
 		       (lambda (a b) (eq? (syntax-e a) (syntax-e b)))
            [(ws . body)
             ;; Skip intraline whitespace to find options:
@@ -78,6 +79,18 @@
 	   [(authorversion . body)
 	    (set! authorversion? "authorversion=true")
 	    (loop #'body)]
+	   [(9pt . body)
+	    (set! font-size "9pt")
+	    (loop #'body)]
+	   [(10pt . body)
+	    (set! font-size "10pt")
+	    (loop #'body)]
+	   [(11pt . body)
+	    (set! font-size "11pt")
+	    (loop #'body)]
+	   [(12pt . body)
+	    (set! font-size "12pt")
+	    (loop #'body)]
 	   
 	   
            ; format options
@@ -110,7 +123,7 @@
             (loop #'body)]
 	    
 	   [body
-            #`(#%module-begin id (post-process #,review? #,screen? #,natbib? #,anonymous? #,authorversion? #,format?) () . body)])))]))
+            #`(#%module-begin id (post-process #,review? #,screen? #,natbib? #,anonymous? #,authorversion? #,font-size #,format?) () . body)])))]))
 
 (define ((post-process . opts) doc)  
   (let ([options


### PR DESCRIPTION
Just like the 10pt option in `scribble/sigplan`,
 putting @9pt @10pt @11pt or @12pt on the #lang line of a `scribble/acmart`
 document passes to corresponding string to `\documentclass[....]`

And just like TeX, it's ok to give multiple font sizes. All but the last are ignored.

(DLS for example want `sigplan` format and 10pt font. I added all the options because, why not.)