### PR TITLE
Remove maketitle

### DIFF
--- a/scribble-doc/scribblings/scribble/acmart.scrbl
+++ b/scribble-doc/scribblings/scribble/acmart.scrbl
@@ -274,3 +274,5 @@ sponsors, @racket[name] is the name of the sponsor.  The
     "National Scribble Foundation"]{http://racket-lang.org} under
     grant No.: @grantnum["NSF7000"]{867-5309}.}
 }|}
+
+@history[#:added "1.20"]

--- a/scribble-doc/scribblings/scribble/acmart.scrbl
+++ b/scribble-doc/scribblings/scribble/acmart.scrbl
@@ -62,19 +62,6 @@ number of options may be used:
 If multiple font size options are used, all but the last are ignored.
 }
 
-@defproc[(maketitle) block?]{
-
-Issues the @tt{maketitle} command.  This @emph{must} be included in
-the document and should occur after the title, authors, and several
-other top-matter commands. (See the
-@hyperlink[acmart-url]{@tt{acmart}} documentation.)
-
-@codeblock|{
-  #lang scribble/acmart
-  @title{Example}
-  @maketitle{}
-}|}
-
 @defproc[(abstract [pre-content pre-content?] ...) block?]{
 
 Generates a @tech{nested flow} for a paper abstract.}
@@ -85,7 +72,14 @@ Similar to @racket[include-section], but incorporates the document in the
 specified module as an abstract. The document must have no title or
 sub-parts.}
 
-@defproc[(title [#:short short-title pre-content? #f] [title pre-content?]) content?]{
+@defproc[(title [#:short short-title pre-content? #f]
+                [#:tag tag (or/c string? (listof string?) #f) #f]
+                [#:tag-prefix prefix (or/c string? module-path? #f) #f]
+                [#:style style (or/c style? string? symbol? #f) #f]
+                [#:version version (or/c string? #f) #f]
+                [#:date date (or/c string? #f) #f]
+                [title pre-content?] ...)
+         title-decl?]{
 
 Specifies the title of the document, optionally with a short version of the title for running heads.}
 
@@ -93,13 +87,23 @@ Specifies the title of the document, optionally with a short version of the titl
 
 Specifies a subtitle.}
 
-@defproc[(author [pre-content pre-conent?] ...) content?]{
+@defproc[(author [#:orcid orcid (or/c pre-content? #f) #f]
+                 [#:affiliation affiliation
+                  (or/c pre-content?
+                        affiliation?
+                        (listof pre-content?)
+                        (listof affiliation?)
+                        #f)
+                  #f]
+                 [#:email email
+                  (or/c pre-content? (listof pre-content?) #f)
+                  #f]
+                 [name pre-content?] ...)
+         block?]{
 
-Specifies an author.}
-
-@defproc[(email [pre-content pre-conent?] ...) content?]{
-
-Specifies an author's email address.}
+ Specifies an author with an optional email address, affiliation, and/or orcid.
+ 
+}
 
 @deftogether[(
 @defproc[(acmJournal [journal pre-content?] ...) content?]
@@ -128,37 +132,37 @@ screen version of the image links to the badge authority.
 
 }
 
-@defproc[(affiliation [content pre-content?] ...) content?]{
-
-Declares information about the affiliation of an author.}
-
-@deftogether[(
-@defproc[(position [content pre-content?] ...) content?]
-@defproc[(institution [content pre-content?] ...) content?]
-@defproc[(department [content pre-content?] ...) content?]
-@defproc[(streetaddress [content pre-content?] ...) content?]
-@defproc[(city [content pre-content?] ...) content?]
-@defproc[(state [content pre-content?] ...) content?]
-@defproc[(postcode [content pre-content?] ...) content?]
-@defproc[(country [content pre-content?] ...) content?]
-)]{
-
-Declares information that is collected for each author.  These commands should
- only be used within an @racket[affiliation] command.}
+@defproc[(affiliation
+          [#:position position (or/c string? #f) #f]
+          [#:institution institution (or/c string? #f) #f]
+          [#:department department (or/c string? #f) #f]
+          [#:street-address street-address (or/c string? #f) #f]
+          [#:city city (or/c string? #f) #f]
+          [#:state state (or/c string? #f) #f]
+          [#:postcode postcode (or/c string? #f) #f]
+          [#:country country (or/c string? #f) #f])
+         affiliation?]{
+ Creates an affiliation object for use with @racket[author].
+}
 
 @codeblock|{
   #lang scribble/acmart
   @title{Some Title}
-  @authorinfo["David Van Horn"
-              @affiliation[
-               #:department "Department of Computer Science and UMIACS"
-               #:institution "University of Maryland"
-               #:city "College Park"
-               #:state "Maryland"]
-              "dvanhorn@cs.umd.edu"]}
+  @author["David Van Horn"
+          #:affiliation @affiliation[
+                         #:department "Department of Computer Science and UMIACS"
+                         #:institution "University of Maryland"
+                         #:city "College Park"
+                         #:state "Maryland"]
+          #:email "dvanhorn@cs.umd.edu"]}
 
   @abstract{This is an abstract.}
 }|
+
+@defproc[(affiliation? [aff any/c]) boolean?]{ Returns
+ @racket[#t] if @racket[aff] is an @racket[affiliation],
+ @racket[#f] otherwise.
+}
 
 @deftogether[(
 @defproc[(terms [content pre-content?] ...) content?]
@@ -195,14 +199,6 @@ defaults to @racket{Received} for the first occurrence and
   @received[#:stage "revised"]{March 2009}
   @received[#:stage "accepted"]{June 2009}
 }|}
-
-@defproc[(citestyle [content pre-content?]) content?]{
-
-Sets the citation style for the paper.}
-
-@defproc[(setcitestyle [content pre-content?] ...) content?]{
-
-Sets customization options for the citation style for the paper.}
 
 @defproc[(teaserfigure [content pre-content?] ...) block?]{
 

--- a/scribble-doc/scribblings/scribble/acmart.scrbl
+++ b/scribble-doc/scribblings/scribble/acmart.scrbl
@@ -149,18 +149,16 @@ Declares information that is collected for each author.  These commands should
 @codeblock|{
   #lang scribble/acmart
   @title{Some Title}
-  @author{David Van Horn}
-  @email|{dvanhorn@cs.umd.edu}|
-  @affiliation{
-    @department{Department of Computer Science and UMIACS}
-    @institution{University of Maryland}
-    @city{College Park}
-    @state{Maryland}}
+  @authorinfo["David Van Horn"
+              @affiliation[
+               #:department "Department of Computer Science and UMIACS"
+               #:institution "University of Maryland"
+               #:city "College Park"
+               #:state "Maryland"]
+              "dvanhorn@cs.umd.edu"]}
 
   @abstract{This is an abstract.}
-  @maketitle{}
 }|
-
 
 @deftogether[(
 @defproc[(terms [content pre-content?] ...) content?]

--- a/scribble-doc/scribblings/scribble/acmart.scrbl
+++ b/scribble-doc/scribblings/scribble/acmart.scrbl
@@ -181,7 +181,9 @@ screen version of the image links to the badge authority.
   @author["David Van Horn"
           #:affiliation @affiliation[
                          #:institution
-                         @institution[#:departments '("Department of Computer Science and UMIACS")]{
+                         @institution[
+                          #:departments (list @institution{Department of Computer Science}
+                                              @institution{UMIACS})]{
                            University of Maryland}
                          #:city "College Park"
                          #:state "Maryland"]

--- a/scribble-doc/scribblings/scribble/acmart.scrbl
+++ b/scribble-doc/scribblings/scribble/acmart.scrbl
@@ -132,17 +132,47 @@ screen version of the image links to the badge authority.
 
 }
 
+@defproc[(email [text pre-content?] ...)
+         email?]{
+ Creates an @racket[email?] object for use with @racket[author].
+}
+
+@defproc[(email? [email any/c]) boolean?]{
+                                          
+ Returns @racket[#t] if @racket[email] is an @racket[email],
+ @racket[#f] otherwise.
+}
+         
+
 @defproc[(affiliation
-          [#:position position (or/c string? #f) #f]
-          [#:institution institution (or/c string? #f) #f]
-          [#:department department (or/c string? #f) #f]
-          [#:street-address street-address (or/c string? #f) #f]
-          [#:city city (or/c string? #f) #f]
-          [#:state state (or/c string? #f) #f]
-          [#:postcode postcode (or/c string? #f) #f]
-          [#:country country (or/c string? #f) #f])
+          [#:position position (or/c pre-content? #f) #f]
+          [#:institution institution (or/c pre-content? institution? #f) #f]
+          [#:street-address street-address (or/c pre-content? #f) #f]
+          [#:city city (or/c pre-content? #f) #f]
+          [#:state state (or/c pre-content? #f) #f]
+          [#:postcode postcode (or/c pre-content? #f) #f]
+          [#:country country (or/c pre-content? #f) #f])
          affiliation?]{
- Creates an affiliation object for use with @racket[author].
+                       
+ Creates an @racket[affiliation?] object for use with @racket[author].
+}
+
+@defproc[(affiliation? [aff any/c]) boolean?]{
+                                              
+ Returns @racket[#t] if @racket[aff] is an
+ @racket[affiliation], @racket[#f] otherwise.
+}
+
+@defproc[(institution [#:departments departments (or/c pre-content? institution? (listof institution)) '()]
+                      [inst institution?] ...)
+         institution?]{
+
+ Creates an @racket[institution?] object for use in @racket[author].}
+
+@defproc[(institution? [inst any/c]) boolean]{
+                                              
+ Returns @racket[#t] if @racket[inst] is an
+ @racket[institution], @racket[#f] otherwise.
 }
 
 @codeblock|{
@@ -150,20 +180,15 @@ screen version of the image links to the badge authority.
   @title{Some Title}
   @author["David Van Horn"
           #:affiliation @affiliation[
-                         #:department "Department of Computer Science and UMIACS"
-                         #:institution "University of Maryland"
+                         #:institution
+                         @institution[#:departments '("Department of Computer Science and UMIACS")]{
+                           University of Maryland}
                          #:city "College Park"
                          #:state "Maryland"]
           #:email "dvanhorn@cs.umd.edu"]}
 
   @abstract{This is an abstract.}
 }|
-
-@defproc[(affiliation? [aff any/c]) boolean?]{
-                                              
- Returns @racket[#t] if @racket[aff] is an
- @racket[affiliation], @racket[#f] otherwise.
-}
 
 @deftogether[(
 @defproc[(terms [content pre-content?] ...) content?]

--- a/scribble-doc/scribblings/scribble/acmart.scrbl
+++ b/scribble-doc/scribblings/scribble/acmart.scrbl
@@ -159,9 +159,10 @@ screen version of the image links to the badge authority.
   @abstract{This is an abstract.}
 }|
 
-@defproc[(affiliation? [aff any/c]) boolean?]{ Returns
- @racket[#t] if @racket[aff] is an @racket[affiliation],
- @racket[#f] otherwise.
+@defproc[(affiliation? [aff any/c]) boolean?]{
+                                              
+ Returns @racket[#t] if @racket[aff] is an
+ @racket[affiliation], @racket[#f] otherwise.
 }
 
 @deftogether[(

--- a/scribble-doc/scribblings/scribble/core.scrbl
+++ b/scribble-doc/scribblings/scribble/core.scrbl
@@ -1799,3 +1799,10 @@ See also @racketmodname[scribble/latex-prefix].}
 
 Used as a @tech{style property} on an @racket[element] to add extra
 arguments to the element's command in Latex output.}
+
+@defstruct[short-tile ([text (or/c string? #f)])]{
+                                                  
+ Used as a @tech{style property} on a @racket[title-decl].
+ Attaches a short title to the title for a @racket[part] if
+ the Latex class file uses a short title.
+}

--- a/scribble-doc/scribblings/scribble/core.scrbl
+++ b/scribble-doc/scribblings/scribble/core.scrbl
@@ -1800,6 +1800,11 @@ See also @racketmodname[scribble/latex-prefix].}
 Used as a @tech{style property} on an @racket[element] to add extra
 arguments to the element's command in Latex output.}
 
+@defstruct[command-optional ([argument string?])]{
+                                                  
+ Used as a @tech{style property} on a @racket[element] to add
+ an optional argument to the element's command in Latex output.}
+
 @defstruct[short-tile ([text (or/c string? #f)])]{
                                                   
  Used as a @tech{style property} on a @racket[title-decl].

--- a/scribble-doc/scribblings/scribble/core.scrbl
+++ b/scribble-doc/scribblings/scribble/core.scrbl
@@ -1803,11 +1803,16 @@ arguments to the element's command in Latex output.}
 @defstruct[command-optional ([argument string?])]{
                                                   
  Used as a @tech{style property} on a @racket[element] to add
- an optional argument to the element's command in Latex output.}
+ an optional argument to the element's command in Latex output.
+
+ @history[#:added "1.20"]
+}
 
 @defstruct[short-tile ([text (or/c string? #f)])]{
                                                   
  Used as a @tech{style property} on a @racket[title-decl].
  Attaches a short title to the title for a @racket[part] if
  the Latex class file uses a short title.
+
+ @history[#:added "1.20"]
 }

--- a/scribble-doc/scribblings/scribble/core.scrbl
+++ b/scribble-doc/scribblings/scribble/core.scrbl
@@ -118,7 +118,7 @@ A @deftech{block} is either a @techlink{table}, an
 
              @itemize[
 
-             @item{An @deftech{content} can be a string, one of a few
+             @item{A @deftech{content} can be a string, one of a few
                    symbols, an instance of @racket[element] (possibly
                    @racket[link-element], etc.), a @racket[multiarg-element], a
                    @techlink{traverse element}, a @techlink{part-relative element}, a
@@ -1808,7 +1808,7 @@ arguments to the element's command in Latex output.}
  @history[#:added "1.20"]
 }
 
-@defstruct[short-tile ([text (or/c string? #f)])]{
+@defstruct[short-title ([text (or/c string? #f)])]{
                                                   
  Used as a @tech{style property} on a @racket[title-decl].
  Attaches a short title to the title for a @racket[part] if

--- a/scribble-lib/info.rkt
+++ b/scribble-lib/info.rkt
@@ -23,4 +23,4 @@
 
 (define pkg-authors '(mflatt eli))
 
-(define version "1.19")
+(define version "1.20")

--- a/scribble-lib/scribble/acmart.rkt
+++ b/scribble-lib/scribble/acmart.rkt
@@ -17,7 +17,14 @@
               #:style (or/c style? string? symbol? #f)
               #:version (or/c string? #f)
               #:date (or/c string? #f))
-             title-decl? #;content?)]
+             title-decl?)]
+ [author (->* () () #:rest (listof pre-content?)
+              paragraph?)]
+ [authorinfo (->* (string?)
+                  ((or/c string? (listof string?))
+                   (or/c string? (listof string?))
+                   #:orcid (or/c string? #f))
+                  paragraph?)]
  [abstract 
   (->* () () #:rest (listof pre-content?)
        block?)]
@@ -233,11 +240,37 @@
                        s)
                      content)))
 
-(provide/contract [author (->* () () #:rest (listof pre-content?)
-                               paragraph?)])
 (define (author . auths)
   (make-paragraph (make-style 'author command-props)
                   (decode-content auths)))
+
+(define (authorinfo name
+                    #:orcid [orcid #f]
+                    [affiliation '()]
+                    [email '()])
+  (author
+   (make-multiarg-element (make-style "SAuthorinfo" multicommand-props)
+                          (list (make-element #f (decode-content (list name)))
+                                (make-element #f
+                                              (if orcid
+                                                  (make-element
+                                                   (make-style "SAuthorOrcid" multicommand-props)
+                                                   (decode-content (list orcid)))
+                                                  '()))
+                                (make-element #f
+                                              (for/list ([a (in-list (if (list? affiliation)
+                                                                         affiliation
+                                                                         (list affiliation)))])
+                                                (make-element
+                                                 (make-style "SAuthorPlace" multicommand-props)
+                                                 (decode-content (list a)))))
+                                (make-element #f
+                                              (for/list ([e (in-list (if (list? email)
+                                                                         email
+                                                                         (list email)))])
+                                                (make-element
+                                                 (make-style "SAuthorEmail" multicommand-props)
+                                                 (decode-content (list e)))))))))
 
 (define-commands subtitle orcid affiliation email
   position institution department streetaddress city state postcode country

--- a/scribble-lib/scribble/acmart.rkt
+++ b/scribble-lib/scribble/acmart.rkt
@@ -1,4 +1,5 @@
 #lang racket/base
+
 (require setup/collects
          racket/contract/base
          racket/list
@@ -7,6 +8,7 @@
          scribble/decode
          scribble/html-properties
          scribble/latex-properties
+         scribble/private/tag
          (for-syntax racket/base))
 
 (struct affiliation (position institution department street-address city state postcode country)
@@ -208,35 +210,6 @@
                                    (decode-string str)))
       (make-element (make-style "ccsdesc" command-props)
                     (decode-string str))))
-
-(define (prefix->string p)
-  (and p (if (string? p) 
-             (datum-intern-literal p)
-             (module-path-prefix->string p))))
-
-(define (gen-tag content)
-  (datum-intern-literal
-   ;; Generate tag from ASCII plus CJK characters. Constraining to
-   ;; ASCII for most purposes helps avoid encoding issues for
-   ;; uncooperative environments, but constraining to ASCII is too
-   ;; uncooperative in another direction for CJK text (i.e., creates
-   ;; too many conflicting tags).
-   (regexp-replace* #px"[^-a-zA-Z0-9_=\u4e00-\u9fff\u3040-\u309F\u30A0-\u30FF]"
-                    (content->string content) "_")))
-
-(define (convert-tag tag content)
-  (if (list? tag)
-    (append-map (lambda (t) (convert-tag t content)) tag)
-    `((part ,(or tag (gen-tag content))))))
-
-(define (convert-part-style who s)
-  (cond
-   [(style? s) s]
-   [(not s) plain]
-   [(string? s) (make-style s null)]
-   [(symbol? s) (make-style #f (list s))]
-   [(and (list? s) (andmap symbol? s)) (make-style #f s)]
-   [else (raise-argument-error who "(or/c style? string? symbol? (listof symbol?) #f)" s)]))
 
 (define (title #:tag [tag #f] #:tag-prefix [prefix #f] #:style [style plain]
                #:version [version #f] #:date [date #f]

--- a/scribble-lib/scribble/acmart.rkt
+++ b/scribble-lib/scribble/acmart.rkt
@@ -10,7 +10,14 @@
          (for-syntax racket/base))
 
 (provide/contract
- [title (->* (pre-content?) #;(#:short pre-content?) title-decl? #;content?)]
+ [title (->* (pre-content?)
+             (#:short pre-content?
+              #:tag (or/c string? (listof string?) #f)
+              #:tag-prefix (or/c string? module-path? #f)
+              #:style (or/c style? string? symbol? #f)
+              #:version (or/c string? #f)
+              #:date (or/c string? #f))
+             title-decl? #;content?)]
  [abstract 
   (->* () () #:rest (listof pre-content?)
        block?)]
@@ -206,17 +213,24 @@
 
 (define (title #:tag [tag #f] #:tag-prefix [prefix #f] #:style [style plain]
                #:version [version #f] #:date [date #f]
+               #:short [short #f]
                . str)
   (let ([content (decode-content str)])
     (make-title-decl (prefix->string prefix)
                      (convert-tag tag content)
                      version
-                     (let ([s (convert-part-style 'title style)])
-                       (if date
-                           (make-style (style-name s)
-                                       (cons (make-document-date date)
-                                             (style-properties s)))
-                           s))
+                     (let* ([s (convert-part-style 'title style)]
+                            [s (if date
+                                   (make-style (style-name s)
+                                               (cons (make-document-date date)
+                                                     (style-properties s)))
+                                   s)]
+                            [s (if short
+                                   (make-style (style-name s)
+                                               (cons (short-title short)
+                                                     (style-properties s)))
+                                   s)])
+                       s)
                      content)))
 
 (provide/contract [author (->* () () #:rest (listof pre-content?)

--- a/scribble-lib/scribble/acmart.rkt
+++ b/scribble-lib/scribble/acmart.rkt
@@ -211,8 +211,11 @@
       (make-element (make-style "ccsdesc" command-props)
                     (decode-string str))))
 
-(define (title #:tag [tag #f] #:tag-prefix [prefix #f] #:style [style plain]
-               #:version [version #f] #:date [date #f]
+(define (title #:tag [tag #f]
+               #:tag-prefix [prefix #f]
+               #:style [style plain]
+               #:version [version #f]
+               #:date [date #f]
                #:short [short #f]
                . str)
   (let ([content (decode-content str)])

--- a/scribble-lib/scribble/acmart.rkt
+++ b/scribble-lib/scribble/acmart.rkt
@@ -272,15 +272,14 @@
                                                  (make-style "SAuthorEmail" multicommand-props)
                                                  (decode-content (list e)))))))))
 
-(define-commands subtitle orcid affiliation email
+(define-commands subtitle
   position institution department streetaddress city state postcode country
   thanks titlenote subtitlenote authornote acmVolume acmNumber acmArticle acmYear acmMonth
   acmArticleSeq acmPrice acmISBN acmDOI
   startPage terms keywords
   setcopyright copyrightyear
   settopmatter ; could be "Rackety"
-  shortauthors
-  setcitstyle)
+  shortauthors)
 
 (define (CCSXML . strs)
   (make-nested-flow (make-style "CCSXML" '())

--- a/scribble-lib/scribble/acmart.rkt
+++ b/scribble-lib/scribble/acmart.rkt
@@ -21,10 +21,20 @@
  [author (->* () () #:rest (listof pre-content?)
               paragraph?)]
  [authorinfo (->* (string?)
-                  ((or/c string? (listof string?))
+                  ((or/c string? multiarg-element? (listof string?) (listof multiarg-element?))
                    (or/c string? (listof string?))
                    #:orcid (or/c string? #f))
                   paragraph?)]
+ [affiliation (->* ()
+                   (#:position (or/c string? #f)
+                    #:institution (or/c string? #f)
+                    #:department (or/c string? #f)
+                    #:street-address (or/c string? #f)
+                    #:city (or/c string? #f)
+                    #:state (or/c string? #f)
+                    #:postcode (or/c string? #f)
+                    #:country (or/c string? #f))
+                   multiarg-element?)]
  [abstract 
   (->* () () #:rest (listof pre-content?)
        block?)]
@@ -261,9 +271,11 @@
                                               (for/list ([a (in-list (if (list? affiliation)
                                                                          affiliation
                                                                          (list affiliation)))])
-                                                (make-element
-                                                 (make-style "SAuthorPlace" multicommand-props)
-                                                 (decode-content (list a)))))
+                                                (if (multiarg-element? a)
+                                                    a 
+                                                    (make-element
+                                                     (make-style "SAuthorPlace" multicommand-props)
+                                                     (decode-content (list a))))))
                                 (make-element #f
                                               (for/list ([e (in-list (if (list? email)
                                                                          email
@@ -272,8 +284,29 @@
                                                  (make-style "SAuthorEmail" multicommand-props)
                                                  (decode-content (list e)))))))))
 
+(define (affiliation #:position [position #f]
+                     #:institution [institution #f]
+                     #:department [department #f]
+                     #:street-address [street-address #f]
+                     #:city [city #f]
+                     #:state [state #f]
+                     #:postcode [postcode #f]
+                     #:country [country #f])
+  (define (maybe-element str content)
+    (and content (make-element str (decode-content (list content)))))
+  (make-multiarg-element
+   (make-style "SAuthorPlace" multicommand-props)
+   (filter values
+           (list (maybe-element "position" position)
+                 (maybe-element "institution" institution)
+                 (maybe-element "department" department)
+                 (maybe-element "streetaddress" street-address)
+                 (maybe-element "city" city)
+                 (maybe-element "state" state)
+                 (maybe-element "postcode" postcode)
+                 (maybe-element "country" country)))))
+
 (define-commands subtitle
-  position institution department streetaddress city state postcode country
   thanks titlenote subtitlenote authornote acmVolume acmNumber acmArticle acmYear acmMonth
   acmArticleSeq acmPrice acmISBN acmDOI
   startPage terms keywords

--- a/scribble-lib/scribble/acmart/acmart.tex
+++ b/scribble-lib/scribble/acmart/acmart.tex
@@ -4,8 +4,10 @@
 % These are replaced by scribble/acmart/style.tex,
 %  which is used in combination with acmart.cls
 
+\newcommand{\SAuthorinfo}[4]{#1}
 \newcommand{\SAuthorPlace}[1]{#1}
 \newcommand{\SAuthorEmail}[1]{#1}
+\newcommand{\SAuthorOrcid}[1]{#1}
 
 \newcommand{\SConferenceInfo}[2]{}
 \newcommand{\SCopyrightYear}[1]{}

--- a/scribble-lib/scribble/acmart/lang.rkt
+++ b/scribble-lib/scribble/acmart/lang.rkt
@@ -145,5 +145,5 @@
   ;; Ensure that "acmart.tex" is used, since "style.tex"
   ;; re-defines commands.
   (struct-copy part doc [to-collect
-                         (cons '(terms) ; FIXME
+                         (cons (terms) ; FIXME
                                (part-to-collect doc))]))

--- a/scribble-lib/scribble/acmart/style.tex
+++ b/scribble-lib/scribble/acmart/style.tex
@@ -19,9 +19,19 @@
 
 % Support plain `author' while enabling `authorinfo': for each
 % use of \SAuthor, check whether it contains an \SAuthorinfo form:
-\def\SAuthor#1{\author{#1}}
+\def\SAuthor#1{\SAutoAuthor#1\SAutoAuthorDone{#1}}
+\def\SAutoAuthorDone#1{}
+\def\SAutoAuthor{\futurelet\next\SAutoAuthorX}
+\def\SAutoAuthorX{\ifx\next\SAuthorinfo \let\Snext\relax \else \let\Snext\SToAuthorDone \fi \Snext}
+\def\SToAuthorDone{\futurelet\next\SToAuthorDoneX}
+\def\SToAuthorDoneX#1{\ifx\next\SAutoAuthorDone \let\Snext\SAddAuthorInfo \else \let\Snext\SToAuthorDone \fi \Snext}
+\newcommand{\SAddAuthorInfo}[1]{\SAuthorinfo{#1}{}{}}
 
+\renewcommand{\SAuthorinfo}[4]{\author{#1}{#2}{#3}{#4}}
 \renewcommand{\SAuthorSep}[1]{}
+\renewcommand{\SAuthorOrcid}[1]{\orcid{#1}}
+\renewcommand{\SAuthorPlace}[1]{\affiliation{#1}}
+\renewcommand{\SAuthorEmail}[1]{\email{#1}}
 
 \renewcommand{\SConferenceInfo}[2]{\conferenceinfo{#1}{#2}}
 \renewcommand{\SCopyrightYear}[1]{\copyrightyear{#1}}

--- a/scribble-lib/scribble/acmart/style.tex
+++ b/scribble-lib/scribble/acmart/style.tex
@@ -1,6 +1,6 @@
 
 % Define \SXtitle to lift \SSubtitle out:
-\def\SXtitle#1{\title{\let\SSubtitle\SSubtitleDrop#1}\SExtractSubtitle#1\SExtractSubtitleDone}
+\newcommand{\SXtitle}[2][]{\title#1{\let\SSubtitle\SSubtitleDrop#2}\SExtractSubtitle#2\SExtractSubtitleDone}
 \def\SSubtitleDrop#1{}
 \def\SExtractSubtitleDone {}
 \def\SExtractSubtitle{\futurelet\next\SExtractSubtitleX}
@@ -12,6 +12,10 @@
 \renewcommand{\titleAndEmptyVersionAndAuthors}[3]{\titleAndVersionAndAuthors{#1}{#2}{#3}}
 \renewcommand{\titleAndVersionAndEmptyAuthors}[3]{\SXtitle{#1}\author{Anonymous Author(s)}\maketitle}
 \renewcommand{\titleAndEmptyVersionAndEmptyAuthors}[3]{\titleAndVersionAndEmptyAuthors{#1}{#2}{#3}}
+\renewcommand{\titleAndVersionAndAuthorsAndShort}[4]{\SXtitle[[#4]]{#1}#3\maketitle}
+\renewcommand{\titleAndEmptyVersionAndAuthorsAndShort}[4]{\titleAndVersionAndAuthorsAndShort{#1}{#2}{#3}{#4}}
+\renewcommand{\titleAndVersionAndEmptyAuthorsAndShort}[4]{\SXtitle[[#4]]{#1}\author{Anonymous Author(s)}\maketitle}
+\renewcommand{\titleAndEmptyVersionAndEmptyAuthorsAndShort}[4]{\titleAndVersionAndEmptyAuthorsAndShort{#1}{#2}{#3}{#4}}
 
 % Support plain `author' while enabling `authorinfo': for each
 % use of \SAuthor, check whether it contains an \SAuthorinfo form:

--- a/scribble-lib/scribble/acmart/style.tex
+++ b/scribble-lib/scribble/acmart/style.tex
@@ -8,9 +8,9 @@
 \def\SExtractSubtitleY{\ifx\next\SExtractSubtitleDone \let\Snext\relax \else \let\Snext\SExtractSubtitle \fi \Snext}
 \def\SWithSubtitle#1{\subtitle{#1}\SExtractSubtitle}
 
-\renewcommand{\titleAndVersionAndAuthors}[3]{\SXtitle{#1}#3}
+\renewcommand{\titleAndVersionAndAuthors}[3]{\SXtitle{#1}#3\maketitle}
 \renewcommand{\titleAndEmptyVersionAndAuthors}[3]{\titleAndVersionAndAuthors{#1}{#2}{#3}}
-\renewcommand{\titleAndVersionAndEmptyAuthors}[3]{\SXtitle{#1}\author{Anonymous Author(s)}}
+\renewcommand{\titleAndVersionAndEmptyAuthors}[3]{\SXtitle{#1}\author{Anonymous Author(s)}\maketitle}
 \renewcommand{\titleAndEmptyVersionAndEmptyAuthors}[3]{\titleAndVersionAndEmptyAuthors{#1}{#2}{#3}}
 
 % Support plain `author' while enabling `authorinfo': for each

--- a/scribble-lib/scribble/base.rkt
+++ b/scribble-lib/scribble/base.rkt
@@ -6,6 +6,7 @@
          "decode-struct.rkt"
          "html-properties.rkt"
          "tag.rkt"
+         "private/tag.rkt"
          scheme/list
          scheme/class
          racket/contract/base
@@ -41,34 +42,6 @@
                           #:rest (listof pre-content?)
                           block?)])
 (provide include-section)
-
-(define (gen-tag content)
-  (datum-intern-literal
-   ;; Generate tag from ASCII plus CJK characters. Constraining to
-   ;; ASCII for most purposes helps avoid encoding issues for
-   ;; uncooperative environments, but constraining to ASCII is too
-   ;; uncooperative in another direction for CJK text (i.e., creates
-   ;; too many conflicting tags).
-   (regexp-replace* #px"[^-a-zA-Z0-9_=\u4e00-\u9fff\u3040-\u309F\u30A0-\u30FF]" (content->string content) "_")))
-
-(define (prefix->string p)
-  (and p (if (string? p) 
-             (datum-intern-literal p)
-             (module-path-prefix->string p))))
-
-(define (convert-tag tag content)
-  (if (list? tag)
-    (append-map (lambda (t) (convert-tag t content)) tag)
-    `((part ,(or tag (gen-tag content))))))
-
-(define (convert-part-style who s)
-  (cond
-   [(style? s) s]
-   [(not s) plain]
-   [(string? s) (make-style s null)]
-   [(symbol? s) (make-style #f (list s))]
-   [(and (list? s) (andmap symbol? s)) (make-style #f s)]
-   [else (raise-argument-error who "(or/c style? string? symbol? (listof symbol?) #f)" s)]))
 
 (define (title #:tag [tag #f] #:tag-prefix [prefix #f] #:style [style plain]
                #:version [version #f] #:date [date #f]

--- a/scribble-lib/scribble/latex-properties.rkt
+++ b/scribble-lib/scribble/latex-properties.rkt
@@ -11,6 +11,7 @@
  [(latex-defaults+replacements latex-defaults)
   ([replacements (hash/c string? (or/c bytes? path-string? (cons/c 'collects (listof bytes?))))])]
  [command-extras ([arguments (listof string?)])]
+ [command-optional ([argument string?])]
  [short-title ([text (or/c string? #f)])])
 
 

--- a/scribble-lib/scribble/latex-properties.rkt
+++ b/scribble-lib/scribble/latex-properties.rkt
@@ -10,4 +10,7 @@
                   [extra-files (listof (or/c path-string? (cons/c 'collects (listof bytes?))))])]
  [(latex-defaults+replacements latex-defaults)
   ([replacements (hash/c string? (or/c bytes? path-string? (cons/c 'collects (listof bytes?))))])]
- [command-extras ([arguments (listof string?)])])
+ [command-extras ([arguments (listof string?)])]
+ [short-title ([text (or/c string? #f)])])
+
+

--- a/scribble-lib/scribble/latex-properties.rkt
+++ b/scribble-lib/scribble/latex-properties.rkt
@@ -13,5 +13,3 @@
  [command-extras ([arguments (listof string?)])]
  [command-optional ([argument string?])]
  [short-title ([text (or/c string? #f)])])
-
-

--- a/scribble-lib/scribble/latex-render.rkt
+++ b/scribble-lib/scribble/latex-render.rkt
@@ -486,7 +486,8 @@
                    [(multiarg-element? e)
                     (check-render)
                     (printf "\\~a" style-name)
-                    (define maybe-optional (findf command-optional? (style-properties style)))
+                    (define maybe-optional
+                      (findf command-optional? (if style (style-properties style) '())))
                     (and maybe-optional (printf "[~a]" maybe-optional))
                     (if (null? (multiarg-element-contents e))
                         (printf "{}")
@@ -496,10 +497,11 @@
                             (render-content i part ri))
                           (printf "}")))]
                    [else
-                    (define maybe-optional (findf command-optional? (style-properties style)))
+                    (define maybe-optional
+                      (findf command-optional? (if style (style-properties style) '())))
                     (wrap e
                           (if maybe-optional
-                              (format "~a[~a]" style-name maybe-optional)
+                              (format "~a[~a]" style-name (command-optional-argument maybe-optional))
                               style-name)
                           tt?)]))]
                [(and (not style-name)

--- a/scribble-lib/scribble/latex-render.rkt
+++ b/scribble-lib/scribble/latex-render.rkt
@@ -486,6 +486,8 @@
                    [(multiarg-element? e)
                     (check-render)
                     (printf "\\~a" style-name)
+                    (define maybe-optional (findf command-optional? (style-properties style)))
+                    (and maybe-optional (printf "[~a]" maybe-optional))
                     (if (null? (multiarg-element-contents e))
                         (printf "{}")
                         (for ([i (in-list (multiarg-element-contents e))])
@@ -494,7 +496,12 @@
                             (render-content i part ri))
                           (printf "}")))]
                    [else
-                    (wrap e style-name tt?)]))]
+                    (define maybe-optional (findf command-optional? (style-properties style)))
+                    (wrap e
+                          (if maybe-optional
+                              (format "~a[~a]" style-name maybe-optional)
+                              style-name)
+                          tt?)]))]
                [(and (not style-name)
                      style
                      (memq 'exact-chars (style-properties style)))

--- a/scribble-lib/scribble/latex-render.rkt
+++ b/scribble-lib/scribble/latex-render.rkt
@@ -83,6 +83,12 @@
              extract-authors
              extract-pretitle)
 
+    (define/public (extract-short-title d)
+      (ormap (lambda (v)
+               (and (short-title? v)
+                    (short-title-text v)))
+             (style-properties (part-style d))))
+
     (define/override (auto-extra-files? v) (latex-defaults? v))
     (define/override (auto-extra-files-paths v) (latex-defaults-extra-files v))
 
@@ -145,14 +151,16 @@
             (let ([vers (extract-version d)]
                   [date (extract-date d)]
                   [pres (extract-pretitle d)]
-                  [auths (extract-authors d)])
+                  [auths (extract-authors d)]
+                  [short (extract-short-title d)])
               (for ([pre (in-list pres)])
                 (printf "\n\n")
                 (do-render-paragraph pre d ri #t #f))
               (when date (printf "\\date{~a}\n" date))
-              (printf "\\titleAnd~aVersionAnd~aAuthors{" 
+              (printf "\\titleAnd~aVersionAnd~aAuthors~a{" 
                       (if (equal? vers "") "Empty" "")
-                      (if (null? auths) "Empty" ""))
+                      (if (null? auths) "Empty" "")
+                      (if short "AndShort" ""))
               (render-content (part-title-content d) d ri)
               (printf "}{~a}{" vers)
               (unless (null? auths)
@@ -161,7 +169,9 @@
                 (unless first? (printf "\\SAuthorSep{}"))
                 (do-render-paragraph auth d ri #t #f)
                 #f)
-              (printf "}\n"))))
+              (if short
+                  (printf "}{~a}\n" short)
+                  (printf "}\n")))))
         (render-part d ri)
         (when whole-doc?
           (printf "\n\n\\postDoc\n\\end{document}\n"))))

--- a/scribble-lib/scribble/private/tag.rkt
+++ b/scribble-lib/scribble/private/tag.rkt
@@ -2,12 +2,13 @@
 
 ;; It might make sense to make these functions public, but since they weren't originally,
 ;; I am going to keep them in the private folder for now.
+;; -- With Love, Leif
+
+(provide (all-defined-out))
 
 (require racket/list
          scribble/core
          "../tag.rkt")
-
-(provide (all-defined-out))
 
 (define (gen-tag content)
   (datum-intern-literal

--- a/scribble-lib/scribble/private/tag.rkt
+++ b/scribble-lib/scribble/private/tag.rkt
@@ -1,0 +1,39 @@
+#lang scheme/base
+
+;; It might make sense to make these functions public, but since they weren't originally,
+;; I am going to keep them in the private folder for now.
+
+(require racket/list
+         scribble/core
+         "../tag.rkt")
+
+(provide (all-defined-out))
+
+(define (gen-tag content)
+  (datum-intern-literal
+   ;; Generate tag from ASCII plus CJK characters. Constraining to
+   ;; ASCII for most purposes helps avoid encoding issues for
+   ;; uncooperative environments, but constraining to ASCII is too
+   ;; uncooperative in another direction for CJK text (i.e., creates
+   ;; too many conflicting tags).
+   (regexp-replace* #px"[^-a-zA-Z0-9_=\u4e00-\u9fff\u3040-\u309F\u30A0-\u30FF]"
+                    (content->string content) "_")))
+
+(define (convert-tag tag content)
+  (if (list? tag)
+    (append-map (lambda (t) (convert-tag t content)) tag)
+    `((part ,(or tag (gen-tag content))))))
+
+(define (convert-part-style who s)
+  (cond
+   [(style? s) s]
+   [(not s) plain]
+   [(string? s) (make-style s null)]
+   [(symbol? s) (make-style #f (list s))]
+   [(and (list? s) (andmap symbol? s)) (make-style #f s)]
+   [else (raise-argument-error who "(or/c style? string? symbol? (listof symbol?) #f)" s)]))
+
+(define (prefix->string p)
+  (and p (if (string? p) 
+             (datum-intern-literal p)
+             (module-path-prefix->string p))))

--- a/scribble-lib/scribble/scribble.tex
+++ b/scribble-lib/scribble/scribble.tex
@@ -301,6 +301,10 @@
 \newcommand{\titleAndVersionAndEmptyAuthors}[3]{\title{#1\\{\normalsize \SVersionBefore{}#2}}#3\maketitle}
 \newcommand{\titleAndEmptyVersionAndAuthors}[3]{\title{#1}\author{#3}\maketitle}
 \newcommand{\titleAndEmptyVersionAndEmptyAuthors}[3]{\title{#1}\maketitle}
+\newcommand{\titleAndVersionAndAuthorsAndShort}[4]{\title[#4]{#1\\{\normalsize \SVersionBefore{}#2}}\author{#3}\maketitle}
+\newcommand{\titleAndVersionAndEmptyAuthorsAndShort}[4]{\title[#4]{#1\\{\normalsize \SVersionBefore{}#2}}#3\maketitle}
+\newcommand{\titleAndEmptyVersionAndAuthorsAndShort}[4]{\title[#4]{#1}\author{#3}\maketitle}
+\newcommand{\titleAndEmptyVersionAndEmptyAuthorsAndShort}[4]{\title[#4]{#1}\maketitle}
 \newcommand{\SAuthor}[1]{#1}
 \newcommand{\SAuthorSep}[1]{\qquad}
 \newcommand{\SVersionBefore}[1]{Version }


### PR DESCRIPTION
    Remove maketitle from scribble/acmart

    This commit is the first that removes maketitle (and the need
    for maketitle) in scribble/acmart. I want to get feedback before
    I document and push.

    (Also I would be willing to rename the `author` function to
    `authorinfo`, to match the scribble/sigplan and existing
    scribble/acmart packages.