### PR TITLE
Add a pretitle style property for nested flows.

### DIFF
--- a/scribble-doc/scribblings/scribble/core.scrbl
+++ b/scribble-doc/scribblings/scribble/core.scrbl
@@ -729,6 +729,8 @@ The following @tech{style properties} are currently recognized:
  @item{@racket[alt-tag] structure --- Generates the indicated HTML tag
        instead of @tt{<blockquote>}.}
 
+ @item{@racket['pretitle] --- For Latex, raises the contents
+   of the flow to above the title.}
 ]}
 
 

--- a/scribble-doc/scribblings/scribble/core.scrbl
+++ b/scribble-doc/scribblings/scribble/core.scrbl
@@ -1115,7 +1115,7 @@ reverse order):
        any number or lists element, while @racket[""] is used in place
        of all non-empty strings.}
 
-]}
+]
 
 @history[#:changed "6.4" @elem{Added @racket[(list/c string? string?)]
                                number items for

--- a/scribble-lib/scribble/acmart.rkt
+++ b/scribble-lib/scribble/acmart.rkt
@@ -141,7 +141,7 @@
 ;; ----------------------------------------
 ;; Abstracts:
 
-(define abstract-style (make-style "abstract" acmart-extras))
+(define abstract-style (make-style "abstract" (cons 'pretitle acmart-extras)))
 
 (define command-props (cons 'command acmart-extras))
 (define multicommand-props (cons 'multicommand acmart-extras))
@@ -149,7 +149,9 @@
 (define (abstract . strs)
   (make-nested-flow
    abstract-style
-   (decode-flow strs)))
+   (list "\\begin{abstract}"
+         (decode-flow strs)
+         "\\end{abstract}")))
 
 (define (extract-abstract p)
   (unless (part? p)

--- a/scribble-lib/scribble/acmart.rkt
+++ b/scribble-lib/scribble/acmart.rkt
@@ -149,9 +149,7 @@
 (define (abstract . strs)
   (make-nested-flow
    abstract-style
-   (list "\\begin{abstract}"
-         (decode-flow strs)
-         "\\end{abstract}")))
+   (decode-flow strs)))
 
 (define (extract-abstract p)
   (unless (part? p)

--- a/scribble-lib/scribble/base-render.rkt
+++ b/scribble-lib/scribble/base-render.rkt
@@ -270,6 +270,29 @@
 
     (define/public (extract-pretitle d)
       (extract-pre-paras d 'pretitle))
+
+    (define/private (extract-pre-flows d sym)
+      (let loop ([l (part-blocks d)])
+        (cond
+          [(null? l) null]
+          [else (let ([v (car l)])
+                  (cond
+                    [(and (nested-flow? v)
+                          (member sym (style-properties (nested-flow-style v))))
+                     (cons v (loop (cdr l)))]
+                    [(compound-paragraph? v)
+                     (append (loop (compound-paragraph-blocks v))
+                             (loop (cdr l)))]
+                    [(itemization? v)
+                     (append (apply append (map loop (itemization-blockss v)))
+                             (loop (cdr l)))]
+                    [(table? v)
+                     (append (apply append (map loop (table-blockss v)))
+                             (loop (cdr l)))]
+                    [else (loop (cdr l))]))])))
+
+    (define/public (extract-pretitle-flows d)
+      (extract-pre-flows d 'pretitle))
     
     ;; ----------------------------------------
 

--- a/scribble-lib/scribble/latex-render.rkt
+++ b/scribble-lib/scribble/latex-render.rkt
@@ -81,7 +81,8 @@
              extract-version
              extract-date
              extract-authors
-             extract-pretitle)
+             extract-pretitle
+             extract-pretitle-flows)
 
     (define/public (extract-short-title d)
       (ormap (lambda (v)
@@ -151,13 +152,18 @@
             (let ([vers (extract-version d)]
                   [date (extract-date d)]
                   [pres (extract-pretitle d)]
+                  [pre-flows (extract-pretitle-flows d)]
                   [auths (extract-authors d)]
                   [short (extract-short-title d)])
               (for ([pre (in-list pres)])
                 (printf "\n\n")
                 (do-render-paragraph pre d ri #t #f))
+              (for ([pre (in-list pre-flows)])
+                (printf "\n\n")
+                (do-render-nested-flow pre d ri #t #f #t))
               (when date (printf "\\date{~a}\n" date))
-              (printf "\\titleAnd~aVersionAnd~aAuthors~a{" 
+              (printf "\\titleAnd~aVersionAnd~aAuthors~a{"
+                      
                       (if (equal? vers "") "Empty" "")
                       (if (null? auths) "Empty" "")
                       (if short "AndShort" ""))
@@ -645,6 +651,7 @@
                part 
                ri
                #t
+               #f
                #f)
               (when (string? s-name)
                 (printf "\\end{~a}" s-name)))
@@ -848,7 +855,7 @@
        [(table? p)
         (render-table* p part ri #f (format "[~a]" mode))]
        [(nested-flow? p)
-        (do-render-nested-flow p part ri #f mode)]
+        (do-render-nested-flow p part ri #f mode #f)]
        [(paragraph? p)
         (do-render-paragraph p part ri #f mode)]))
 
@@ -879,7 +886,7 @@
         (printf "\\end{~a}" mode)
         null))
 
-    (define/private (do-render-nested-flow t part ri single-column? as-box-mode)
+    (define/private (do-render-nested-flow t part ri single-column? as-box-mode show-pre?)
       (let* ([props (style-properties (nested-flow-style t))]
              [kind (or (and as-box-mode
                             (or
@@ -900,29 +907,31 @@
              [multicommand? (memq 'multicommand props)]
              [command? (or (and as-box-mode (not multicommand?))
                            (memq 'command props))])
-        (cond
-         [command? (printf "\\~a{" kind)]
-         [multicommand? (printf "\\~a" kind)]
-         [else (printf "\\begin{~a}" kind)])
-        (parameterize ([current-table-mode (if (or single-column?
-                                                   (not (current-table-mode)))
-                                               (current-table-mode)
-                                               (list "nested-flow" t))])
-          (if as-box-mode
-              (for-each (lambda (p) 
-                          (when multicommand? (printf "{"))
-                          (render-boxable-block p part ri as-box-mode)
-                          (when multicommand? (printf "}")))
-                        (nested-flow-blocks t))
-              (render-flow (nested-flow-blocks t) part ri #f multicommand?)))
-        (cond
-         [command? (printf "}")]
-         [multicommand? (void)]
-         [else (printf "\\end{~a}" kind)])
-        null))
+        (unless (and (not show-pre?)
+                     (member 'pretitle props))
+          (cond
+            [command? (printf "\\~a{" kind)]
+            [multicommand? (printf "\\~a" kind)]
+            [else (printf "\\begin{~a}" kind)])
+          (parameterize ([current-table-mode (if (or single-column?
+                                                     (not (current-table-mode)))
+                                                 (current-table-mode)
+                                                 (list "nested-flow" t))])
+            (if as-box-mode
+                (for-each (lambda (p) 
+                            (when multicommand? (printf "{"))
+                            (render-boxable-block p part ri as-box-mode)
+                            (when multicommand? (printf "}")))
+                          (nested-flow-blocks t))
+                (render-flow (nested-flow-blocks t) part ri #f multicommand?)))
+          (cond
+            [command? (printf "}")]
+            [multicommand? (void)]
+            [else (printf "\\end{~a}" kind)])
+          null)))
 
     (define/override (render-nested-flow t part ri starting-item?)
-      (do-render-nested-flow t part ri #f #f))
+      (do-render-nested-flow t part ri #f #f #f))
 
     (define/override (render-compound-paragraph t part ri starting-item?)
       (let ([kind (style-name (compound-paragraph-style t))]

--- a/scribble-lib/scribble/latex-render.rkt
+++ b/scribble-lib/scribble/latex-render.rkt
@@ -81,8 +81,7 @@
              extract-version
              extract-date
              extract-authors
-             extract-pretitle
-             extract-pretitle-flows)
+             extract-pretitle-content)
 
     (define/public (extract-short-title d)
       (ormap (lambda (v)
@@ -151,16 +150,16 @@
           (when (part-title-content d)
             (let ([vers (extract-version d)]
                   [date (extract-date d)]
-                  [pres (extract-pretitle d)]
-                  [pre-flows (extract-pretitle-flows d)]
+                  [pres (extract-pretitle-content d)]
                   [auths (extract-authors d)]
                   [short (extract-short-title d)])
               (for ([pre (in-list pres)])
                 (printf "\n\n")
-                (do-render-paragraph pre d ri #t #f))
-              (for ([pre (in-list pre-flows)])
-                (printf "\n\n")
-                (do-render-nested-flow pre d ri #t #f #t))
+                (cond
+                  [(paragraph? pre)
+                   (do-render-paragraph pre d ri #t #f)]
+                  [(nested-flow? pre)
+                   (do-render-nested-flow pre d ri #t #f #t)]))
               (when date (printf "\\date{~a}\n" date))
               (printf "\\titleAnd~aVersionAnd~aAuthors~a{"
                       
@@ -193,7 +192,7 @@
                          (and d (positive? d)))))
           (when (eq? (style-name (part-style d)) 'index)
             (printf "\\twocolumn\n\\parskip=0pt\n\\addcontentsline{toc}{section}{Index}\n"))
-          (let ([pres (extract-pretitle d)])
+          (let ([pres (extract-pretitle-content d)])
             (for ([pre (in-list pres)])
               (printf "\n\n")
               (do-render-paragraph pre d ri #t #f)))


### PR DESCRIPTION
This allows us to raise nested flows above the title. So that we do
things like raise the abstract above the title:

```
\begin{abstract}
Abstract text
\end{abstract}
\titleCommand{...}
```

This style is required by the acmart style guide.

(Documentation will be in the next commit.)