### PR TITLE
patch for '\Large' in jfp1.cls

### DIFF
--- a/scribble-lib/scribble/jfp/replacements.tex
+++ b/scribble-lib/scribble/jfp/replacements.tex
@@ -1,1 +1,1 @@
-\renewcommand{\packageRelsize}{}
+\renewcommand\Large{\@setfontsize\@xvpt{18}}


### PR DESCRIPTION
Closes #103 .

I don't know why it's okay to use `xvpt` in `replacements.tex`, but this fix works for me on small documents and on the bigger example.

- - - 

Fixes an incompatibility between jfp1.cls and the 'relsize' package.

Justification for the fix:

1. `pdflatex` fails on this document

```
    \documentclass{jfp1}
    \begin{document}
    \maketitle
    hello {\Large world}
    \end{document}
```

2. `pdflatex` succeeds on this document

```
    \documentclass{jfp1}
    \renewcommand\Large{\@setfontsize\@xvpt{18}}
    \begin{document}
    \maketitle
    hello {\Large world}
    \end{document}
```

I do not know why (1) fails.