### PR TITLE
doc: point 'tabular #:style' to 'table' docs

### DIFF
--- a/scribble-doc/scribblings/scribble/base.scrbl
+++ b/scribble-doc/scribblings/scribble/base.scrbl
@@ -260,6 +260,7 @@ used for a new cell. A @racket['cont] must not appear as the first
 cell in a row.
 
 The @racket[style] argument is handled the same as @racket[para].
+See @racket[table] for a list of recognized @tech{style names} and @tech{style properties}.
 
 If @racket[sep] is not @racket[#f], it is inserted as a new column
 between every column in the table; note that any


### PR DESCRIPTION
@mflatt thanks for the help on slack, `#:style 'block` does produce a LaTeX `tabular`

I think this PR fixes a typo.

If it's not a typo, I'll change it to a "see also". Because the docs for `para` didn't help me understand `tabular`'s `#:style`
(If I had the list of styles from `table`'s docs, I could have at least tried those to see what happened.)