### PR TITLE
acmart: remove subtitle extraction

### DIFF
--- a/scribble-lib/scribble/acmart/style.tex
+++ b/scribble-lib/scribble/acmart/style.tex
@@ -1,12 +1,4 @@
-
-% Define \SXtitle to lift \SSubtitle out:
-\newcommand{\SXtitle}[2][]{\title#1{\let\SSubtitle\SSubtitleDrop#2}\SExtractSubtitle#2\SExtractSubtitleDone}
-\def\SSubtitleDrop#1{}
-\def\SExtractSubtitleDone {}
-\def\SExtractSubtitle{\futurelet\next\SExtractSubtitleX}
-\def\SExtractSubtitleX#1{\ifx{#1}\SSubtitle \let\Snext\SWithSubtitle \else \let\Snext\SExtractSubtitleY \fi \Snext}
-\def\SExtractSubtitleY{\ifx\next\SExtractSubtitleDone \let\Snext\relax \else \let\Snext\SExtractSubtitle \fi \Snext}
-\def\SWithSubtitle#1{\subtitle{#1}\SExtractSubtitle}
+\newcommand{\SXtitle}[2][]{\title[#1]{#2}}
 
 \renewcommand{\titleAndVersionAndAuthors}[3]{\SXtitle{#1}#3\maketitle}
 \renewcommand{\titleAndEmptyVersionAndAuthors}[3]{\titleAndVersionAndAuthors{#1}{#2}{#3}}

--- a/scribble-lib/scribble/acmart/style.tex
+++ b/scribble-lib/scribble/acmart/style.tex
@@ -1,12 +1,20 @@
-\newcommand{\SXtitle}[2][]{\title[#1]{#2}}
 
+\makeatletter
+\def\ifemptyarg#1{% https://tex.stackexchange.com/questions/308/different-command-definitions-with-and-without-optional-argument#58638
+  \if\relax\detokenize{#1}\relax
+    \expandafter\@firstoftwo
+  \else
+    \expandafter\@secondoftwo
+  \fi}
+\makeatother
+\newcommand{\SXtitle}[2][]{\ifemptyarg{#1}{\title{#2}}{\title[#1]{#2}}}
 \renewcommand{\titleAndVersionAndAuthors}[3]{\SXtitle{#1}#3\maketitle}
 \renewcommand{\titleAndEmptyVersionAndAuthors}[3]{\titleAndVersionAndAuthors{#1}{#2}{#3}}
 \renewcommand{\titleAndVersionAndEmptyAuthors}[3]{\SXtitle{#1}\author{Anonymous Author(s)}\maketitle}
 \renewcommand{\titleAndEmptyVersionAndEmptyAuthors}[3]{\titleAndVersionAndEmptyAuthors{#1}{#2}{#3}}
-\renewcommand{\titleAndVersionAndAuthorsAndShort}[4]{\SXtitle[[#4]]{#1}#3\maketitle}
+\renewcommand{\titleAndVersionAndAuthorsAndShort}[4]{\SXtitle[#4]{#1}#3\maketitle}
 \renewcommand{\titleAndEmptyVersionAndAuthorsAndShort}[4]{\titleAndVersionAndAuthorsAndShort{#1}{#2}{#3}{#4}}
-\renewcommand{\titleAndVersionAndEmptyAuthorsAndShort}[4]{\SXtitle[[#4]]{#1}\author{Anonymous Author(s)}\maketitle}
+\renewcommand{\titleAndVersionAndEmptyAuthorsAndShort}[4]{\SXtitle[#4]{#1}\author{Anonymous Author(s)}\maketitle}
 \renewcommand{\titleAndEmptyVersionAndEmptyAuthorsAndShort}[4]{\titleAndVersionAndEmptyAuthorsAndShort{#1}{#2}{#3}{#4}}
 
 % Support plain `author' while enabling `authorinfo': for each

--- a/scribble-lib/scribble/acmart/style.tex
+++ b/scribble-lib/scribble/acmart/style.tex
@@ -1,20 +1,11 @@
 
-\makeatletter
-\def\ifemptyarg#1{% https://tex.stackexchange.com/questions/308/different-command-definitions-with-and-without-optional-argument#58638
-  \if\relax\detokenize{#1}\relax
-    \expandafter\@firstoftwo
-  \else
-    \expandafter\@secondoftwo
-  \fi}
-\makeatother
-\newcommand{\SXtitle}[2][]{\ifemptyarg{#1}{\title{#2}}{\title[#1]{#2}}}
-\renewcommand{\titleAndVersionAndAuthors}[3]{\SXtitle{#1}#3\maketitle}
+\renewcommand{\titleAndVersionAndAuthors}[3]{\title{#1}#3\maketitle}
 \renewcommand{\titleAndEmptyVersionAndAuthors}[3]{\titleAndVersionAndAuthors{#1}{#2}{#3}}
-\renewcommand{\titleAndVersionAndEmptyAuthors}[3]{\SXtitle{#1}\author{Anonymous Author(s)}\maketitle}
+\renewcommand{\titleAndVersionAndEmptyAuthors}[3]{\title{#1}\author{Anonymous Author(s)}\maketitle}
 \renewcommand{\titleAndEmptyVersionAndEmptyAuthors}[3]{\titleAndVersionAndEmptyAuthors{#1}{#2}{#3}}
-\renewcommand{\titleAndVersionAndAuthorsAndShort}[4]{\SXtitle[#4]{#1}#3\maketitle}
+\renewcommand{\titleAndVersionAndAuthorsAndShort}[4]{\title[#4]{#1}#3\maketitle}
 \renewcommand{\titleAndEmptyVersionAndAuthorsAndShort}[4]{\titleAndVersionAndAuthorsAndShort{#1}{#2}{#3}{#4}}
-\renewcommand{\titleAndVersionAndEmptyAuthorsAndShort}[4]{\SXtitle[#4]{#1}\author{Anonymous Author(s)}\maketitle}
+\renewcommand{\titleAndVersionAndEmptyAuthorsAndShort}[4]{\title[#4]{#1}\author{Anonymous Author(s)}\maketitle}
 \renewcommand{\titleAndEmptyVersionAndEmptyAuthorsAndShort}[4]{\titleAndVersionAndEmptyAuthorsAndShort{#1}{#2}{#3}{#4}}
 
 % Support plain `author' while enabling `authorinfo': for each


### PR DESCRIPTION
cc @LeifAndersen 

Change implementation of `@title` to just use `\title`.
Do not try to extract a subtitle from the argument.

This fixes a bug, where the `Title` meta-data in the PDF for a document titled
 "Foo" was "oo" (same title with first letter missing). So, e.g., Google chrome
 would show "oo" as the tab title for the document.

- - -

Why remove the `\let` altogether?
  1. I don't think we need it in `scribble/acmart`, because there's a separate `@subtitle` command
  2. Keeping it generates two warnings when running LaTeX:

     ```
       Package hyperref Warning: Token not allowed in a PDF string (PDFDocEncoding):
       (hyperref)                removing `\<let>-command' on input line 674.

       Package hyperref Warning: Token not allowed in a PDF string (PDFDocEncoding):
       (hyperref)                removing `\SSubtitle' on input line 674.
     ```

The "visual" bug was probably due to this warning; after removing the `\let`
 and `\SSubtitle` then only `\SubtitleDrop` and the actual title are left.
I guess `\SSubtitleDrop` removed the first character of the title.
(Why only the first? I don't know.)

The LaTeX warning from `hyperref` is probably because acmart expects the
 argument to `\title` to be a raw string. Though, the docs don't explicitly
 say this. They only say "It is expected that this command [`\title`] is inserted
 by the author of the manuscript."