### PR TITLE
doc: fix 'scribble-eval-handler' order of arguments

### DIFF
--- a/scribble-doc/scribblings/scribble/examples.scrbl
+++ b/scribble-doc/scribblings/scribble/examples.scrbl
@@ -282,13 +282,13 @@ an evaluator (e.g., because it is defined in a module body).}
 
 
 @defparam[scribble-eval-handler handler 
-          ((any/c . -> . any) any/c boolean? . -> . any)]{
+          ((any/c . -> . any) boolean? any/c . -> . any)]{
 
 A parameter that serves as a hook for evaluation. The evaluator to use
-is supplied as the first argument to the parameter's value, and the
-second argument is the form to evaluate. The last argument is
-@racket[#t] if exceptions are being captured (to display exception
-results), @racket[#f] otherwise.}
+is supplied as the first argument to the parameter's value.
+The second argument is @racket[#t] if exceptions are being captured (to display
+exception results), @racket[#f] otherwise.
+The third argument is the form to evaluate.}
 
 @defparam[scribble-exn->string handler (-> (or/c exn? any/c) string?)]{
   A parameter that controls how exceptions are rendered by 


### PR DESCRIPTION
Change the documented order of arguments to match the implementation / uses in `scribble/eval.rkt` and `scriblib/gui-eval.rkt`.

- - -

Alternatively, we could change the implementation to match the docs.
- on one hand, I think making the "catch exceptions?" flag the 3rd argument is easier to explain & remember
- on the other hand, it's a larger change and will make calls to `(scribble-eval-handler)` a little more awkward-looking (`((scribble-eval-handler) ev (.... large term to eval ....) #f)`)

Just changing the docs is my preference, and if nobody speaks up I'll just merge this in a few days.