### PR TITLE
add contracts to scribble/example

### DIFF
--- a/scribble-lib/scribble/example.rkt
+++ b/scribble-lib/scribble/example.rkt
@@ -1,22 +1,36 @@
 #lang racket/base
 
 (require "eval.rkt"
+         racket/contract
          (only-in "struct.rkt" make-paragraph)
          (for-syntax racket/base
                      syntax/parse))
 
+(define lang-option/c
+  (or/c module-path? (list/c 'special symbol?) (cons/c 'begin list?)))
+
+(define eval-factory/c
+  (->* [(listof module-path?)] [#:pretty-print? any/c #:lang lang-option/c] any))
+
 (provide examples
 
          ;; Re-exports:
-         
-         make-base-eval
-         make-base-eval-factory
-         make-eval-factory
-         close-eval
+         (contract-out
+           [make-base-eval
+            (->* [] [#:pretty-print? any/c #:lang lang-option/c] #:rest any/c any)]
+           [make-base-eval-factory
+            eval-factory/c]
+           [make-eval-factory
+            eval-factory/c]
+           [close-eval
+            (-> any/c any)]
 
-         scribble-exn->string
-         scribble-eval-handler
-         make-log-based-eval)
+           [scribble-exn->string
+            (-> any/c string?)]
+           [scribble-eval-handler
+            (parameter/c (-> (-> any/c any) boolean? any/c any))]
+           [make-log-based-eval
+            (-> path-string? (or/c 'record 'replay) any)]))
 
 (define example-title
   (make-paragraph (list "Example:")))

--- a/scribble-test/tests/scribble/example.rkt
+++ b/scribble-test/tests/scribble/example.rkt
@@ -1,0 +1,45 @@
+#lang racket/base
+(require rackunit scribble/example setup/path-to-relative
+         (only-in racket/contract exn:fail:contract:blame?))
+
+(test-case "scribble/example contracts"
+  (define blames-this-module?
+    (let* ([this-module
+            (path->relative-string/library
+              (variable-reference->module-source (#%variable-reference)))]
+           [blame-rx (regexp (string-append "blaming: " this-module))])
+      (λ (x)
+        (and (exn:fail:contract:blame? x)
+             (regexp-match? blame-rx (exn-message x))))))
+
+  (check-exn blames-this-module?
+    (λ () (make-base-eval #:lang #f '(+ 2 2))))
+  (check-exn blames-this-module?
+    (λ () (make-base-eval #:lang '(+ 2 2))))
+
+  (check-exn blames-this-module?
+    (λ () (make-base-eval-factory 'racket/dict)))
+  (check-exn blames-this-module?
+    (λ () (make-base-eval-factory '() #:lang #f '(+ 2 2))))
+  (check-exn blames-this-module?
+    (λ () (make-base-eval-factory '() #:lang '(+ 2 2))))
+
+  (check-exn blames-this-module?
+    ;; https://github.com/racket/scribble/issues/117
+    (λ () (make-eval-factory 'racket/dict)))
+  (check-exn blames-this-module?
+    (λ () (make-eval-factory '() #:lang #f '(+ 2 2))))
+  (check-exn blames-this-module?
+    (λ () (make-eval-factory '() #:lang '(+ 2 2))))
+
+  (check-exn blames-this-module?
+    (λ () (scribble-eval-handler #f)))
+  (check-exn blames-this-module?
+    (λ () (scribble-eval-handler (λ (ev t) t))))
+
+  (check-exn blames-this-module?
+    (λ () (make-log-based-eval #f 'record)))
+  (check-exn blames-this-module?
+    (λ () (make-log-based-eval "foo.rkt" 'bad-mode)))
+
+)


### PR DESCRIPTION
Add contracts to `scribble/example` exports, and tests to make sure negative blame gets assigned as expected.

Closes #117