### PR TITLE
acmart: a little better for empty documents

### DIFF
--- a/scribble-doc/scribblings/scribble/acmart.scrbl
+++ b/scribble-doc/scribblings/scribble/acmart.scrbl
@@ -13,6 +13,17 @@ LaTeX style defaults to use the @hyperlink[acmart-url]{@tt{acmart}}
 class for typesetting publications for the Association of Computing
 Machinery.}
 
+@bold{Note:} a @racketmodname[scribble/acmart] document must include a
+@racket[title] and @racket[author].
+
+Example:
+
+@verbatim[#:indent 2]|{
+  #lang scribble/acmart
+  @title{Surreal Numbers}
+  @author{Ursula N. Owens}
+}|
+
 @deftogether[(
 @defidform[manuscript]
 @defidform[acmsmall]

--- a/scribble-lib/scribble/acmart.rkt
+++ b/scribble-lib/scribble/acmart.rkt
@@ -80,6 +80,8 @@
  [CCSXML 
   (->* () () #:rest (listof pre-content?)
        any/c)])
+(provide
+  invisible-element-to-collect-for-acmart-extras)
 
 (define-syntax-rule (defopts name ...)
   (begin (define-syntax (name stx)
@@ -135,6 +137,9 @@
     (list
      (make-css-addition (abs "acmart.css"))
      (make-tex-addition (abs "acmart.tex")))))
+
+(define invisible-element-to-collect-for-acmart-extras
+  (make-element (make-style "invisible-element-to-collect-for-acmart-extras" acmart-extras) '()))
 
 ;; ----------------------------------------
 ;; Abstracts:

--- a/scribble-lib/scribble/acmart/lang.rkt
+++ b/scribble-lib/scribble/acmart/lang.rkt
@@ -145,5 +145,5 @@
   ;; Ensure that "acmart.tex" is used, since "style.tex"
   ;; re-defines commands.
   (struct-copy part doc [to-collect
-                         (cons (terms) ; FIXME
+                         (cons invisible-element-to-collect-for-acmart-extras
                                (part-to-collect doc))]))


### PR DESCRIPTION
1. Change `add-acmart-styles` to add an element WITHOUT the `pretitle` style
   for the collects phase. With this, an empty `#lang scribble/acmart` document
   builds an empty PDF.
2. Add documentation for a "minimal" `scribble/acmart` document.

re #121 : This PR doesn't add a helpful error/warning message, but at least it's the same behavior now as `scribble/sigplan`.