### PR TITLE
Small improvements for scriblib/bibtex and acmart

### DIFF
--- a/scribble-lib/scribble/acmart.rkt
+++ b/scribble-lib/scribble/acmart.rkt
@@ -80,6 +80,8 @@
  [CCSXML 
   (->* () () #:rest (listof pre-content?)
        any/c)])
+(provide
+  invisible-element-to-collect-for-acmart-extras)
 
 (define-syntax-rule (defopts name ...)
   (begin (define-syntax (name stx)
@@ -135,6 +137,9 @@
     (list
      (make-css-addition (abs "acmart.css"))
      (make-tex-addition (abs "acmart.tex")))))
+
+(define invisible-element-to-collect-for-acmart-extras
+  (make-element (make-style "invisible-element-to-collect-for-acmart-extras" acmart-extras) '()))
 
 ;; ----------------------------------------
 ;; Abstracts:

--- a/scribble-lib/scribble/acmart.rkt
+++ b/scribble-lib/scribble/acmart.rkt
@@ -80,8 +80,6 @@
  [CCSXML 
   (->* () () #:rest (listof pre-content?)
        any/c)])
-(provide
-  invisible-element-to-collect-for-acmart-extras)
 
 (define-syntax-rule (defopts name ...)
   (begin (define-syntax (name stx)
@@ -138,9 +136,6 @@
      (make-css-addition (abs "acmart.css"))
      (make-tex-addition (abs "acmart.tex")))))
 
-(define invisible-element-to-collect-for-acmart-extras
-  (make-element (make-style "invisible-element-to-collect-for-acmart-extras" acmart-extras) '()))
-
 ;; ----------------------------------------
 ;; Abstracts:
 
@@ -182,19 +177,19 @@
 (define (acmBadgeR #:url [url #f] str)
   (make-paragraph (make-style 'pretitle '())
                   (if url
-                      (make-multiarg-element (make-style "SacmBadgeRURL" multicommand-props)
+                      (make-multiarg-element (make-style "SacmBadgeRURL" (cons 'exact-chars multicommand-props))
                                              (list (decode-string url)
                                                    (decode-string str)))
-                      (make-element (make-style "acmBadgeR" command-props)
+                      (make-element (make-style "acmBadgeR" (cons 'exact-chars command-props))
                                     (decode-string str)))))
   
 (define (acmBadgeL #:url [url #f] str)
   (make-paragraph (make-style 'pretitle '())
                   (if url
-                      (make-multiarg-element (make-style "SacmBadgeLURL" multicommand-props)
+                      (make-multiarg-element (make-style "SacmBadgeLURL" (cons 'exact-chars multicommand-props))
                                              (list (decode-string url)
                                                    (decode-string str)))
-                      (make-element (make-style "acmBadgeL" command-props)
+                      (make-element (make-style "acmBadgeL" (cons 'exact-chars command-props))
                                     (decode-string str)))))
 
 (define (received #:stage [s #f] str)

--- a/scribble-lib/scriblib/bibtex.rkt
+++ b/scribble-lib/scriblib/bibtex.rkt
@@ -471,6 +471,13 @@
                             #:date (raw-attr "year")
                             #:location (raw-attr "school")
                             #:url (raw-attr "url"))]
+                 ["phdthesis"
+                  (make-bib #:title (raw-attr "title")
+                            #:author (parse-author (raw-attr "author"))
+                            #:date (raw-attr "year")
+                            #:location (dissertation-location #:institution (raw-attr "school")
+                                                              #:degree "PhD")
+                            #:url (raw-attr "url"))]
                  ["techreport"
                   (make-bib #:title (raw-attr "title")
                             #:author (parse-author (raw-attr "author"))


### PR DESCRIPTION
- Add support for PhD bib entries in scriblib/bibtex
- Use exact chars in acmart badge commands to avoid escaping URL characters