### PR TITLE
autobib book-location: fix capitalization of ordinal editions

### DIFF
--- a/scribble-lib/scriblib/autobib.rkt
+++ b/scribble-lib/scriblib/autobib.rkt
@@ -522,11 +522,17 @@
                 s)])
     s))
 
+(define (string-capitalize str)
+  (if (non-empty-string? str)
+      (let ([chars (string->list str)])
+        (list->string (cons (char-upcase (car chars)) (cdr chars))))
+      str))
+  
 (define (book-location
          #:edition [edition #f]
          #:publisher [publisher #f])
   (let* ([s (if edition
-                @elem{@(string-titlecase (to-string edition)) edition}
+                @elem{@(string-capitalize (to-string edition)) edition}
                 #f)]
          [s (if publisher
                 (if s

--- a/scribble-test/tests/scriblib/autobib.rkt
+++ b/scribble-test/tests/scriblib/autobib.rkt
@@ -1,6 +1,6 @@
 #lang racket/base
 
-(require rackunit scriblib/autobib)
+(require rackunit scriblib/autobib scribble/base scribble/core)
 
 (test-case "define-cite"
   ;; Check that `define-cite` binds the expected identifiers
@@ -38,6 +38,23 @@
     (λ () (book-location #:edition 'B #:publisher 'Elsiver)))
   (check-exn exn:fail?
     (λ () (book-location))))
+
+(define (mk-bookloc-elem/ed ed) (element (style #f '()) (list ed " edition")))
+
+(test-case "book-location-edition-capitalization"
+  (check-equal? (book-location #:edition 'a)
+                (mk-bookloc-elem/ed "A"))
+  (check-equal? (book-location #:edition "first")
+                (mk-bookloc-elem/ed "First"))
+  (check-equal? (book-location #:edition 'Third)
+                (mk-bookloc-elem/ed "Third"))
+  (check-equal? (book-location #:edition 1)
+                (mk-bookloc-elem/ed "1"))
+  (check-equal? (book-location #:edition "1st")
+                (mk-bookloc-elem/ed "1st"))
+  (check-equal? (book-location #:edition "4th")
+                (mk-bookloc-elem/ed "4th")))
+
 
 (test-case "techrpt-location"
   (check-not-exn


### PR DESCRIPTION
Fixes capitalization when `book-location` edition is an ordinal.

Eg, the following file:
```
#lang scribble/base
@(require scriblib/autobib)
@(define htdp
  (make-bib #:title "HTDP"
            #:author "MRMS"
            #:is-book? #t
            #:location (book-location #:edition "1st" #:publisher "MIT")
            #:date "2001"))
@(define-cite cite citet gen-bib)
@cite[htdp]
@(gen-bib)
```
capitalizes the edition incorrectly:
```
(MRMS 2001)
Bibliography
MRMS. HTDP. 1St edition. MIT, 2001.
```