### PR TITLE
html-render: define 'normalize' for symbol "path elements"

### DIFF
--- a/scribble-lib/scribble/html-render.rkt
+++ b/scribble-lib/scribble/html-render.rkt
@@ -2018,7 +2018,8 @@
   (define e-d (and d (explode (path->complete-path d))))
   (define p-in? (in-plt? e-p))
   (define d-in? (and d (in-plt? e-d)))
-  (define (normalize p) (normal-case-path p))
+  (define (normalize p)
+    (if (memq p '(up same)) p (normal-case-path p)))
   ;; use an absolute link if the link is from outside the plt tree
   ;; going in (or if d is #f)
   (if (not (and d (cond


### PR DESCRIPTION
Define `(normalize 'up)` and `(normalize 'same)`, instead of passing these symbols to `normal-case-path` and erroring.


I'm not sure if this is the right fix, or if `normal-case-path` should be updated.