### PR TITLE
pressing "S" on the page body focuses to the search box

### DIFF
--- a/scribble-lib/scribble/scribble-common.js
+++ b/scribble-lib/scribble/scribble-common.js
@@ -168,3 +168,13 @@ AddOnLoad(function(){
     indicator.innerHTML = label;
     indicator.style.display = "block";
   });
+
+// Pressing "S" focuses on the "...search manuals..." text field
+AddOnLoad(function(){
+  window.addEventListener("keypress", function(event) {
+    if (event && event.charCode == 115 && event.target == document.body) {
+      var field = document.getElementsByClassName("searchbox")[0];
+      field.focus();
+    }
+  }, false);
+});


### PR DESCRIPTION
The Racket docs are extremely helpful and useful while programming, and are some of the highest quality documentation I've worked with. I spend a lot of time scanning pages of documentation when programming in Racket.

One thing that would be helpful, is a hotkey that focuses on the "... search manuals ..." text field. For instance, Rust's generated documentation allows you to press S to focus on the search bar ([screenshot](https://0x0.st/5WL.png)). I, and others who have a primarily keyboard-oriented workflow, would appreciate a similar feature.

In this PR I have implemented the same functionality: pressing S focuses to the search bar.