### PR TITLE
doc: require 'scribble/example' in 'examples' example

### DIFF
--- a/scribble-doc/scribblings/scribble/examples.scrbl
+++ b/scribble-doc/scribblings/scribble/examples.scrbl
@@ -177,10 +177,11 @@ As an example,
 @codeblock|{
 #lang scribble/manual
 @(require racket/sandbox
-          scribble/eval)
+          scribble/example)
 @(define my-evaluator
    (parameterize ([sandbox-output 'string]
-                  [sandbox-error-output 'string])
+                  [sandbox-error-output 'string]
+                  [sandbox-memory-limit 50])
      (make-evaluator 'typed/racket/base)))
 
 @examples[#:eval my-evaluator


### PR DESCRIPTION
Also increase the memory limit in the example.
(On my machine, this example fails if the memory limit is 37MB or less.)

Closes #137 