### PR TITLE
acmart fixes

### DIFF
--- a/scribble-doc/scribblings/scribble/acmart.scrbl
+++ b/scribble-doc/scribblings/scribble/acmart.scrbl
@@ -239,28 +239,28 @@ defaults to @racket{Received} for the first occurrence and
   @received[#:stage "accepted"]{June 2009}
 }|}
 
-@defproc[(teaserfigure [content pre-content?] ...) block?]{
+@defproc[(teaserfigure [content pre-flow?] ...) block?]{
 
 Creates a teaser figure to appear before main text.}
 
 @deftogether[(
-@defproc[(sidebar [content pre-content?] ...) block?]
-@defproc[(marginfigure [content pre-content?] ...) block?]
-@defproc[(margintable [content pre-content?] ...) block?]
+@defproc[(sidebar [content pre-flow?] ...) block?]
+@defproc[(marginfigure [content pre-flow?] ...) block?]
+@defproc[(margintable [content pre-flow?] ...) block?]
 )]{
 
 In the @racket[sigchi-a] format, special sidebars,
  tables and figures on the margin.}
 
 @deftogether[(
-@defproc[(printonly [content pre-content?] ...) block?]
-@defproc[(screenonly [content pre-content?] ...) block?]
-@defproc[(anonsuppress [content pre-content?] ...) block?]
+@defproc[(printonly [content pre-flow?] ...) block?]
+@defproc[(screenonly [content pre-flow?] ...) block?]
+@defproc[(anonsuppress [content pre-flow?] ...) block?]
 )]{
 Marks content to be included only for print or screen
 editions, or excluded from anonymous editions.}
 
-@defproc[(acks [content pre-content?] ...) block?]{
+@defproc[(acks [content pre-flow?] ...) block?]{
 
 Creates an unnumbered section ``Acknowledgments'' section, unless the
 @racket[anonymous] mode is selected.}

--- a/scribble-lib/scribble/acmart.rkt
+++ b/scribble-lib/scribble/acmart.rkt
@@ -70,9 +70,9 @@
  [acmConference 
   (-> string? string? string? block?)]
  [grantsponsor 
-  (-> string? string? string? block?)]
+  (-> string? string? string? content?)]
  [grantnum 
-  (->* (string? string?) (#:url string?) block?)]
+  (->* (string? string?) (#:url string?) content?)]
  [acmBadgeR (->* (string?) (#:url string?) block?)]
  [acmBadgeL (->* (string?) (#:url string?) block?)]
  [received (->* (string?) (#:stage string?) block?)]
@@ -163,22 +163,20 @@
                                                (decode-string venue)))))
 
 (define (grantsponsor id name url)
-  (make-paragraph (make-style 'pretitle '())
-                  (make-multiarg-element (make-style "grantsponsor" multicommand-props)
-                                         (list (decode-string id)
-                                               (decode-string name)
-                                               (decode-string url)))))
+  (make-multiarg-element (make-style "grantsponsor" multicommand-props)
+                         (list (decode-string id)
+                               (decode-string name)
+                               (decode-string url))))
 
 (define (grantnum #:url [url #f] id num)
-  (make-paragraph (make-style 'pretitle '())
-                  (if url
-                      (make-multiarg-element (make-style "SgrantnumURL" multicommand-props)
-                                             (list (decode-string url)
-                                                   (decode-string id)
-                                                   (decode-string num)))
-                      (make-multiarg-element (make-style "grantnum" multicommand-props)
-                                             (list (decode-string id)
-                                                   (decode-string num))))))
+  (if url
+      (make-multiarg-element (make-style "SgrantnumURL" multicommand-props)
+                             (list (decode-string url)
+                                   (decode-string id)
+                                   (decode-string num)))
+      (make-multiarg-element (make-style "grantnum" multicommand-props)
+                             (list (decode-string id)
+                                   (decode-string num)))))
 
 (define (acmBadgeR #:url [url #f] str)
   (make-paragraph (make-style 'pretitle '())

--- a/scribble-lib/scribble/acmart.rkt
+++ b/scribble-lib/scribble/acmart.rkt
@@ -106,7 +106,7 @@
 (define-syntax-rule (define-environments name ...)
   (begin
     (begin
-      (provide/contract [name (->* () () #:rest (listof pre-content?)
+      (provide/contract [name (->* () () #:rest (listof pre-flow?)
                                    block?)])
       (define (name . str)
         (make-nested-flow (make-style (symbol->string 'name) acmart-extras)
@@ -117,7 +117,7 @@
 (define-syntax-rule (define-comment-environments name ...)
   (begin
     (begin
-      (provide/contract [name (->* () () #:rest (listof pre-content?)
+      (provide/contract [name (->* () () #:rest (listof pre-flow?)
                                    block?)])
       (define (name . str)
         (make-nested-flow (make-style (symbol->string 'name) acmart-extras)

--- a/scribble-lib/scribble/acmart/acmart-load.tex
+++ b/scribble-lib/scribble/acmart/acmart-load.tex
@@ -5,5 +5,6 @@
 \renewcommand\packageTocstyle\relax
 \let\Footnote\undefined
 \let\captionwidth\undefined
+\renewcommand{\renewrmdefault}{}
 % END acmart-load.tex
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
The first commit makes the acmart style file disable the default Scribble redefinition of `\rmdefault`, since that plays badly with acmart. I'm pretty sure @LeifAndersen had the same problem, but I don't know how she fixed it.

The second one make `grantsponsor` and `grantnum` work. I think the old versions may have been a cut-and-paste error that kept too much from a related function.

The third commit is in the same vein, but for some other functions and more a question of generalizing contracts than making things work at all.