### PR TITLE
add '\phantomsection' to starx macros

### DIFF
--- a/scribble-lib/scribble/scribble.tex
+++ b/scribble-lib/scribble/scribble.tex
@@ -332,10 +332,10 @@
 \newcommand{\Ssubsubsubsubsectionstar}[1]{\Ssubsubsubsectionstar{#1}}
 
 % "starx" means unnumbered but in ToC:
-\newcommand{\Spartstarx}[2]{\Spartstar{#2}\addcontentsline{toc}{part}{#1}}
-\newcommand{\Ssectionstarx}[2]{\Ssectionstar{#2}\addcontentsline{toc}{section}{#1}}
-\newcommand{\Ssubsectionstarx}[2]{\Ssubsectionstar{#2}\addcontentsline{toc}{subsection}{#1}}
-\newcommand{\Ssubsubsectionstarx}[2]{\Ssubsubsectionstar{#2}\addcontentsline{toc}{subsubsection}{#1}}
+\newcommand{\Spartstarx}[2]{\Spartstar{#2}\phantomsection\addcontentsline{toc}{part}{#1}}
+\newcommand{\Ssectionstarx}[2]{\Ssectionstar{#2}\phantomsection\addcontentsline{toc}{section}{#1}}
+\newcommand{\Ssubsectionstarx}[2]{\Ssubsectionstar{#2}\phantomsection\addcontentsline{toc}{subsection}{#1}}
+\newcommand{\Ssubsubsectionstarx}[2]{\Ssubsubsectionstar{#2}\phantomsection\addcontentsline{toc}{subsubsection}{#1}}
 \newcommand{\Ssubsubsubsectionstarx}[2]{\Ssubsubsubsectionstar{#2}}
 \newcommand{\Ssubsubsubsubsectionstarx}[2]{\Ssubsubsubsubsectionstar{#2}}
 


### PR DESCRIPTION
WARNING: I've only tested this on small examples, need to check more about whether this is safe.
In particular, I don't know what this does for documents that don't `\usepackage{hyperref}`.

- - -

Add `\phantomsection` before every call to `\addtocentry` in a Scribble "starx" macro.

This adds a link that hyperref can jump to,
 so the labels added by `scriblib/autobib` work.

Closes #124