### PR TITLE
hyperlink customization, especially for acmart

### DIFF
--- a/scribble-doc/scribblings/scribble/base.scrbl
+++ b/scribble-doc/scribblings/scribble/base.scrbl
@@ -613,7 +613,8 @@ Generates a literal hyperlinked URL.}
 @defproc[(secref [tag string?]
                  [#:doc module-path (or/c module-path? #f) #f]
                  [#:tag-prefixes prefixes (or/c (listof string?) #f) #f]
-                 [#:underline? underline? any/c #t])
+                 [#:underline? underline? any/c #t]
+                 [#:link-render-style ref-style (or/c link-render-style? #f)])
          element?]{
 
 Inserts a reference to the section tagged @racket[tag].
@@ -634,32 +635,35 @@ reach the @racket[tag] section. When @racket[#:doc] is not provided,
 the @racket[prefixes] path is relative to any enclosing section (i.e.,
 the youngest ancestor that produces a match).
 
-For HTML output, the generated reference is the hyperlinked title of
-the elements in the section's title content, except that elements with
-the @racket['aux] @tech{style property} are omitted in the hyperlink
-label. If @racket[underline?] is @racket[#f], then the hyperlink is
-rendered in HTML without an underline.
+For the result @racket[link-element], if @racket[ref-style] is not
+@racket[#f], then it is attached as a @tech{style property} and
+affects the rendering of the link. Alternatively, an enclosing
+@racket[part] can have a link-render style that adjusts the rendering
+style for all links within the @tech{part}. See @racket[link-element]
+for more information about the rendering of section references.
 
-For Latex output, the generated reference's format depends on the
-document style. By default, only the section number is shown in the
-reference, but the @racketmodname[scribble/manual] style shows the
-title after the section number. Customize the output (see
-@secref["config"]) by redefining the @ltx{BookRef}, @|etc|, macros (see
-@secref["builtin-latex"]).
-
+If @racket[underline?] is @racket[#f], then a @tech{style} is attached
+to the result @racket[link-element] so that the hyperlink is rendered
+in HTML without an underline
+       
 In Racket documentation that is rendered to HTML, clicking on a
 section title normally shows the @racket[secref] call that is needed
-to link to the section.}
+to link to the section.
+
+@history[#:changed "1.25" @elem{Added the @racket[#:link-render-style] argument.}]}
 
 
 @defproc[(Secref [tag string?]
                  [#:doc module-path (or/c module-path? #f) #f]
                  [#:tag-prefixes prefixes (or/c (listof string?) #f) #f]
-                 [#:underline? underline? any/c #t])
+                 [#:underline? underline? any/c #t]
+                 [#:link-render-style ref-style (or/c link-render-style? #f)])
          element?]{
 
 Like @racket[secref], but if the rendered form of the reference starts
-with a word (e.g., ``section''), then the word is capitalized.}
+with a word (e.g., ``section''), then the word is capitalized.
+
+@history[#:changed "1.25" @elem{Added the @racket[#:link-render-style] argument.}]}
 
 
 @defproc[(seclink [tag string?] 

--- a/scribble-doc/scribblings/scribble/core.scrbl
+++ b/scribble-doc/scribblings/scribble/core.scrbl
@@ -9,6 +9,7 @@
                      scriblib/render-cond
                      xml/xexpr
                      net/url-structs
+                     scriblib/figure
                      (only-in scribble/html-render render-mixin)))
 
 @title[#:tag "core"]{Structures And Processing}
@@ -514,6 +515,11 @@ The recognized @tech{style properties} are as follows:
         module path plus a section-tag string, so that the user can
         create a reference to the section.}
 
+ @item{@racket[link-render-style] structure --- Determines the default
+       rendering of links to sections or other destinations within the
+       section. See also @racket[link-element] and
+       @racket[current-link-render-style].}
+
 ]
 
 The @racket[to-collect] field contains @techlink{content} that is
@@ -525,7 +531,8 @@ sub-parts).
 
 The @racket[parts] field contains sub-parts.
 
-@history[#:changed "1.25" @elem{Added @racket['no-index] support.}]}
+@history[#:changed "1.25" @elem{Added @racket['no-index] support.}
+         #:changed "1.26" @elem{Added @racket[link-render-style] support.}]}
 
 
 @defstruct[paragraph ([style style?] [content content?])]{
@@ -982,17 +989,64 @@ field.}
 
 @defstruct[(link-element element) ([tag tag?])]{
 
-Hyperlinks the content to @racket[_tag].
+Represents a hyperlinks to @racket[_tag].
 
+Normally, the content of the element is rendered as the hyperlink.
 When @racket[_tag] is a part tag and the content of the element is
-@racket[null], then the hyperlink uses the target part's number and/or
-title as the content. In that case, if the section number is preceded
-by a word, the word starts in uppercase if the element's style includes a
-@racket['uppercase] property.
+@racket[null], however, rendering is treated specially based on the
+@racket[_mode] value of a @racket[link-render-style] @tech{style
+property}:
 
-The following symbol is recognized as a @tech{style property}:
+@itemlist[
+
+ @item{For HTML output, in the @racket['default] mode, the generated
+       reference is the hyperlinked title of the elements in the
+       section's title content, except that elements with the
+       @racket['aux] @tech{style property} are omitted in the
+       hyperlink label.
+
+       In @racket['number] mode, the section title is not shown.
+       Instead, the word ``section'' is shown followed by a
+       hyperlinked section number. The word ``section'' starts in
+       uppercase if the element's style includes a @racket['uppercase]
+       property.}
+
+ @item{For Latex/PDF output, the generated reference's format can
+       depend on the document style in addition the @racket[_mode].
+       For the @racket['default] mode and a default document style, a
+       section number is shown by the word ``section'' followed by the
+       section number, and the word ``section'' and the section number
+       are together hyperlinked. The word ``section'' starts in
+       uppercase if the element's style includes a @racket['uppercase]
+       property. The @racketmodname[scribble/manual] style uses the
+       symbol ``§'' in place of the word ``section''.
+
+       In @racket['number] mode, rendering is the same, except that
+       only the number is hyperlinked, not the word ``section'' or
+       the ``§'' symbol.
+
+       A new document style can customize Latex/PDF output (see
+       @secref["config"]) by redefining the @ltx{SecRefLocal}, @|etc|,
+       macros (see @secref["builtin-latex"]). The @ltx{SecRef},
+       @|etc|, variants are used in @racket['number] mode.}
+
+]
+
+If a @racket[link-render-style] @tech{style property} is not attached
+to a @racket[link-element] that refers to a part, a
+@racket[link-render-style] @tech{style property} that is attached to
+an enclosing part is used, since attaching a
+@racket[link-render-style] @tech{style property} to a part causes
+@racket[current-link-render-style] to be set while rendering the part.
+Otherwise, the render-time value of @racket[current-link-render-style]
+determine's a @racket[link-element]'s rendering.
+
+The following style properties are recognized in addition to the style
+properties for all @racket[element]s:
 
 @itemize[
+
+ @item{@racket[link-render-style] structure --- As described above.}
 
  @item{@indexed-racket['indirect-link] --- For HTML output, treats the link as
        ``external''. When rendering to HTML and the
@@ -1002,7 +1056,9 @@ The following symbol is recognized as a @tech{style property}:
        some cases, patched by JavaScript when the documentation is
        viewed in a browser).}
 
-]}
+]
+
+@history[#:changed "1.26" @elem{Added @racket[link-render-style] support.}]}
 
 
 @defstruct[(index-element element) ([tag tag?]
@@ -1139,7 +1195,7 @@ reverse order):
 
 ]
 
-@history[#:changed "6.4" @elem{Added @racket[(list/c string? string?)]
+@history[#:changed "1.1" @elem{Added @racket[(list/c string? string?)]
                                number items for
                                @tech{numberer}-generated section
                                numbers.}]}
@@ -1374,7 +1430,7 @@ Return @racket[#t] if @racket[v] is @racket[#f], an exact non-negative
 integer, a string, or a list containing two strings. See @racket[collected-info]
 for information on how different representations are used for numbering.
 
-@history[#:added "6.4"]}
+@history[#:added "1.1"]}
 
 
 @deftogether[(
@@ -1429,7 +1485,38 @@ number for each subsection. If @racket[numberer-step] produces a plain
 string for the rendered number, then it is not added as a prefix to
 subsection numbers. See also @racket[collected-info].
 
-@history[#:added "6.4"]}
+@history[#:added "1.1"]}
+
+
+@defstruct[link-render-style ([mode (or/c 'default 'number)])]{
+
+Used as a @tech{style property} for a @racket[part] or a specific
+@racket[link-element] to control the way that a hyperlink is rendered
+for a part via @racket[secref] or for a figure via @racket[figure-ref]
+from @racketmodname[scriblib/figure].
+
+The @racket['default] and @racket['number] modes represent generic
+hyperlink-style configurations that could make sense for various kinds
+of references. The @racket['number] style is intended to mean that a
+specific number is shown for the reference and that only the number is
+hyperlinked. The @racket['default] style is more flexible, allowing a
+more appropriate choice for the rendering context, such as using the
+target section's name for a hyperlink in HTML.
+
+@history[#:added "1.26"]}
+
+
+@defparam[current-link-render-style style link-render-style?]{
+
+A parameter that determines the default rendering style for a section
+link.
+
+When a @racket[part] has a @racket[link-render-style] as one of its
+@tech{style properties}, then the @racket[current-link-render-style]
+parameter is set during the @tech{resolve pass} and @tech{render pass}
+for the @racket[part]'s content.
+
+@history[#:added "1.26"]}
 
 
 @defstruct[collect-info ([fp any/c] [ht any/c] [ext-ht any/c] 

--- a/scribble-doc/scriblib/scribblings/autobib.scrbl
+++ b/scribble-doc/scriblib/scribblings/autobib.scrbl
@@ -58,7 +58,7 @@ includes a citation to section 8 of the Racket reference.
                        (code:line #:date=? date-compare-expr)
                        (code:line #:cite-author cite-author-id)
                        (code:line #:cite-year cite-year-id)])
-              #:contracts ([style-expr (or/c author+date-style number-style)]
+              #:contracts ([style-expr (or/c number-style author+date-style author+date-square-bracket-style)]
                            [spaces-expr number?]
                            [disambiguator-expr (or/c #f (-> exact-nonnegative-integer? element?))]
                            [render-date-expr (or/c #f (-> date? element?))]

--- a/scribble-doc/scriblib/scribblings/figure.scrbl
+++ b/scribble-doc/scriblib/scribblings/figure.scrbl
@@ -85,14 +85,28 @@ The @racket[left] binding is a synonym for @racket[left-figure-style],
 provided for backward compatibility.}
 
 
-@defproc[(figure-ref [tag string?] ...+) element?]{
+@defproc[(figure-ref [tag string?] ...+
+                     [#:link-render-style link-style (or/c link-render-style? #f)])
+         element?]{
 
-Generates a reference to one or more figures, using a lowercase word ``figure''.}
+Generates a reference to one or more figures, using a lowercase word ``figure''.
+
+If @racket[link-style] or @racket[(current-link-render-style)] at the
+time of rendering indicates the @racket['number] style mode, then the
+word ``figure'' itself is not hyperlinked. Otherwise, the word
+@racket[figure] is hyperlinked together with the referenced figure's
+number.
+
+@history[#:changed "1.26" @elem{Added the @racket[#:link-render-style] argument.}]}
 
 
-@defproc[(Figure-ref [tag string?] ...+) element?]{
+@defproc[(Figure-ref [tag string?] ...+
+                     [#:link-render-style link-style (or/c link-render-style? #f)])
+         element?]{
 
-Generates a reference to one or more figures, capitalizing the word ``Figure''.}
+Like @racket[figure-ref], but capitalizes the word ``Figure''.
+
+@history[#:changed "1.26" @elem{Added the @racket[#:link-render-style] argument.}]}
 
 
 @defproc[(Figure-target [tag string?]

--- a/scribble-lib/info.rkt
+++ b/scribble-lib/info.rkt
@@ -23,4 +23,4 @@
 
 (define pkg-authors '(mflatt eli))
 
-(define version "1.25")
+(define version "1.26")

--- a/scribble-lib/scribble/acmart/acmart.tex
+++ b/scribble-lib/scribble/acmart/acmart.tex
@@ -23,4 +23,6 @@
 % Normally gets re-written by the title macro:
 \newcommand{\SSubtitle}[1]{{\bf #1}}
 
-
+% Use ACM color; it would be better to use `citecolor` here somehow,
+% but I can't figure out how to do that
+\newcommand{\AutobibLink}[1]{\color{ACMPurple}{#1}}

--- a/scribble-lib/scribble/acmart/lang.rkt
+++ b/scribble-lib/scribble/acmart/lang.rkt
@@ -142,8 +142,16 @@
 		   #:replacements (hash "scribble-load-replace.tex" (scribble-file "acmart/acmart-load.tex"))))))
 
 (define (add-acmart-styles doc)
-  ;; Ensure that "acmart.tex" is used, since "style.tex"
-  ;; re-defines commands.
-  (struct-copy part doc [to-collect
-                         (cons invisible-element-to-collect-for-acmart-extras
-                               (part-to-collect doc))]))
+  (struct-copy part doc
+               [to-collect
+                ;; Ensure that "acmart.tex" is used, since "style.tex"
+                ;; re-defines commands.
+                (cons invisible-element-to-collect-for-acmart-extras
+                      (part-to-collect doc))]
+               [style (let ([s (part-style doc)])
+                        (struct-copy style s
+                                     [properties
+                                      ;; Immitate Latex-based links where only the
+                                      ;; number part is hyperlinked.
+                                      (cons (link-render-style 'number)
+                                            (style-properties s))]))]))

--- a/scribble-lib/scribble/base.rkt
+++ b/scribble-lib/scribble/base.rkt
@@ -549,45 +549,55 @@
 
 ;; ----------------------------------------
 
-(provide/contract
- [elemtag (->* ((or/c taglet? generated-tag?))
-               ()
-               #:rest (listof pre-content?)
-               element?)]
- [elemref (->* ((or/c taglet? generated-tag?))
-               (#:underline? any/c)
-               #:rest (listof pre-content?)
-               element?)]
- [secref (->* (string?)
-              (#:doc module-path?
-                     #:tag-prefixes (or/c #f (listof string?))
-                     #:underline? any/c)
-              element?)]
- [Secref (->* (string?)
-              (#:doc module-path?
-                     #:tag-prefixes (or/c #f (listof string?))
-                     #:underline? any/c)
-              element?)]
- [seclink (->* (string?)
+(provide
+ (contract-out
+  [elemtag (->* ((or/c taglet? generated-tag?))
+                ()
+                #:rest (listof pre-content?)
+                element?)]
+  [elemref (->* ((or/c taglet? generated-tag?))
+                (#:underline? any/c)
+                #:rest (listof pre-content?)
+                element?)]
+  [secref (->* (string?)
                (#:doc module-path?
-                      #:tag-prefixes (or/c #f (listof string?))
-                      #:underline? any/c
-                      #:indirect? any/c)
-               #:rest (listof pre-content?)
+                #:tag-prefixes (or/c #f (listof string?))
+                #:underline? any/c
+                #:link-render-style (or/c #f link-render-style?))
                element?)]
- [other-doc (->* (module-path?)
-                 (#:underline? any/c
-                               #:indirect (or/c #f content?))
-                 element?)])
+  [Secref (->* (string?)
+               (#:doc module-path?
+                #:tag-prefixes (or/c #f (listof string?))
+                #:underline? any/c
+                #:link-render-style (or/c #f link-render-style?))
+               element?)]
+  [seclink (->* (string?)
+                (#:doc module-path?
+                 #:tag-prefixes (or/c #f (listof string?))
+                 #:underline? any/c
+                 #:indirect? any/c)
+                #:rest (listof pre-content?)
+                element?)]
+  [other-doc (->* (module-path?)
+                  (#:underline? any/c
+                   #:indirect (or/c #f content?))
+                  element?)]))
 
 (define (elemtag t . body)
   (make-target-element #f (decode-content body) `(elem ,t)))
 (define (elemref #:underline? [u? #t] t . body)
   (make-link-element (if u? #f "plainlink") (decode-content body) `(elem ,t)))
 
-(define (secref s #:underline? [u? #t] #:doc [doc #f] #:tag-prefixes [prefix #f])
-  (make-link-element (if u? #f "plainlink") null (make-section-tag s #:doc doc #:tag-prefixes prefix)))
-(define (Secref s #:underline? [u? #t] #:doc [doc #f] #:tag-prefixes [prefix #f])
+(define (secref s #:underline? [u? #t] #:doc [doc #f] #:tag-prefixes [prefix #f]
+                #:link-render-style [link-style #f])
+  (make-link-element (let ([name (if u? #f "plainlink")])
+                       (if link-style
+                           (style name (list link-style))
+                           name))
+                     null
+                     (make-section-tag s #:doc doc #:tag-prefixes prefix)))
+(define (Secref s #:underline? [u? #t] #:doc [doc #f] #:tag-prefixes [prefix #f]
+                #:link-render-style [link-style #f])
   (let ([le (secref s #:underline? u? #:doc doc #:tag-prefixes prefix)])
     (make-link-element
      (make-style (element-style le) '(uppercase))

--- a/scribble-lib/scribble/core.rkt
+++ b/scribble-lib/scribble/core.rkt
@@ -162,6 +162,36 @@
 
 ;; ----------------------------------------
 
+(define-struct link-render-style (mode)
+  #:constructor-name link-render-style
+  #:property
+  prop:serializable
+  (make-serialize-info
+   (lambda (s)
+     (vector (link-render-style-mode s)))
+   #'deserialize-link-render-style
+   #f
+   (or (current-load-relative-directory) (current-directory))))
+
+(provide deserialize-link-render-style)
+(define deserialize-link-render-style
+  (make-deserialize-info (lambda (s)
+                           (link-render-style s))
+                         (lambda (tag init-val)
+                           (error "cannot allocate link-render-style for cycle"))))
+
+(define current-link-render-style (make-parameter (link-render-style 'default)))
+
+(provide
+ link-render-style?
+ link-render-style-mode
+ (contract-out
+  [link-render-style ((or/c 'default 'number)
+                      . -> . link-render-style?)]
+  [current-link-render-style (parameter/c link-render-style?)]))
+
+;; ----------------------------------------
+
 (define-struct numberer (tag step-proc initial-value)
   #:constructor-name numberer
   #:property

--- a/scribble-lib/scribble/scribble.tex
+++ b/scribble-lib/scribble/scribble.tex
@@ -59,7 +59,7 @@
 
 \newcommand{\BookRefLocalUN}[2]{\hyperref[#1]{\BookRefUN{#2}}}
 \newcommand{\ChapRefLocalUN}[2]{\SecRefLocalUN{#1}{#2}}
-\newcommand{\SecRefLocalUN}[2]{\SecRefUN{#2} on page~\pageref{#1}}
+\newcommand{\SecRefLocalUN}[2]{\hyperref[#1]{\SecRefUN{#2}}}
 \newcommand{\PartRefLocalUN}[2]{\SecRefLocalUN{#1}{#2}}
 \newcommand{\BookRefLocalUCUN}[2]{\BookRefLocalUN{#1}{#2}}
 \newcommand{\ChapRefLocalUCUN}[2]{\ChapRefLocalUN{#1}{#2}}

--- a/scribble-lib/scribble/scribble.tex
+++ b/scribble-lib/scribble/scribble.tex
@@ -66,6 +66,8 @@
 \newcommand{\SecRefLocalUCUN}[2]{\SecRefLocalUN{#1}{#2}}
 \newcommand{\PartRefLocalUCUN}[2]{\PartRefLocalUN{#1}{#2}}
 
+\newcommand{\SectionNumberLink}[2]{\hyperref[#1]{#2}}
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Fonts
 

--- a/scribble-lib/scriblib/autobib.rkt
+++ b/scribble-lib/scriblib/autobib.rkt
@@ -70,26 +70,28 @@
      (lambda (renderer part ri)
        ;; (list which key) should be mapped to the bibliography element.
        (define s (resolve-get part ri `(,which ,key)))
-       (make-link-element #f
-                          (list (or s "???")
-                                (cond [(not (send style disambiguate-date?)) '()]
-                                      [disambiguation ;; should be a list of bib-entries with same author/date
-                                       (define disambiguation*
-                                         (add-between (for/list ([bib (in-list disambiguation)])
-                                                        (define key (auto-bib-key bib))
-                                                        (define maybe-disambiguation
-                                                          (resolve-get part ri `(autobib-disambiguation ,key)))
-                                                        (case maybe-disambiguation
-                                                          [(#f) #f]
-                                                          [(unambiguous) #f]
-                                                          [else (make-link-element #f maybe-disambiguation `(autobib ,key))]))
-                                                      ","))
-                                       (cond [(not (car disambiguation*)) '()] ;; the bib was unambiguous
-                                             [else disambiguation*])]
-                                      [else '()])
-                                (if with-specific?
-                                    (auto-bib-specific bib-entry)
-                                    ""))
+       (define content
+         (list (or s "???")
+               (cond [(not (send style disambiguate-date?)) '()]
+                     [disambiguation ;; should be a list of bib-entries with same author/date
+                      (define disambiguation*
+                        (add-between (for/list ([bib (in-list disambiguation)])
+                                       (define key (auto-bib-key bib))
+                                       (define maybe-disambiguation
+                                         (resolve-get part ri `(autobib-disambiguation ,key)))
+                                       (case maybe-disambiguation
+                                         [(#f) #f]
+                                         [(unambiguous) #f]
+                                         [else (make-link-element "AutobibLink" maybe-disambiguation `(autobib ,key))]))
+                                     ","))
+                      (cond [(not (car disambiguation*)) '()] ;; the bib was unambiguous
+                            [else disambiguation*])]
+                     [else '()])
+               (if with-specific?
+                   (auto-bib-specific bib-entry)
+                   "")))
+       (make-link-element "AutobibLink"
+                          content
                           `(autobib ,(auto-bib-key bib-entry))))
      (lambda () "(???)")
      (lambda () "(???)"))))

--- a/scribble-lib/scriblib/autobib.tex
+++ b/scribble-lib/scriblib/autobib.tex
@@ -8,3 +8,5 @@
 \newcommand{\Autocolbibentry}[1]{\setlength{\ABcollength}{\linewidth-5ex}\parbox[t]{\ABcollength}{#1\vspace{1.0ex}}}
 
 \newcommand{\Autobibref}[1]{#1}
+
+\providecommand{\AutobibLink}[1]{#1}

--- a/scribble-lib/scriblib/figure.tex
+++ b/scribble-lib/scriblib/figure.tex
@@ -15,7 +15,7 @@
 \newcommand{\LegendContinued}[1]{\Legend{#1}}
 
 \newcommand{\FigureTarget}[2]{#1}
-\newcommand{\FigureRef}[2]{\hyperref[#2]{#1}}
+\newcommand{\FigureRef}[2]{#1}
 
 \newlength{\FigOrigskip}
 \FigOrigskip=\parskip


### PR DESCRIPTION
These commits are about making `#lang scribble/acmart` do more of the right things to match the current acmart style – especially with respect to hyperlinks in PDF and link coloring.

I'm not too happy with all the ways that built-in things have to be adjusted here and the way that some things remain hardwired, but this is the best approach I've found so far.