### PR TITLE
Add authorsaddresses field.

### DIFF
--- a/scribble-doc/scribblings/scribble/acmart.scrbl
+++ b/scribble-doc/scribblings/scribble/acmart.scrbl
@@ -203,6 +203,23 @@ screen version of the image links to the badge authority.
   @abstract{This is an abstract.}
 }|
 
+@defproc[(authorsaddresses [addresses pre-content?] ...) block?]{
+ Sets the text for the authors' addresses on the first page
+ in some styles. By default this field is set to the authors'
+ affiliation.
+
+ The @racket[addresses] parameter is the address text. As a
+ special case the empty list removes the adresses field entirely.
+
+ @codeblock|{
+  #lang scribble/acmart @acmsmall
+  @title{A fancy paper}
+  @author["Leif Andersen"]
+  @authoraddresses{}
+}|
+
+ @history[#:added "1.26"]}
+
 @deftogether[(
 @defproc[(terms [content pre-content?] ...) content?]
 @defproc[(keywords [content pre-content?] ...) content?]

--- a/scribble-doc/scribblings/scribble/acmart.scrbl
+++ b/scribble-doc/scribblings/scribble/acmart.scrbl
@@ -208,14 +208,14 @@ screen version of the image links to the badge authority.
  in some styles. By default this field is set to the authors'
  affiliation.
 
- The @racket[addresses] parameter is the address text. As a
- special case the empty list removes the adresses field entirely.
+ The @racket[addresses] parameter takes the address text. As a
+ special case the empty list removes the addresses field entirely.
 
  @codeblock|{
   #lang scribble/acmart @acmsmall
   @title{A fancy paper}
-  @author["Leif Andersen"]
-  @authoraddresses{}
+  @author["Ronon Dex"]
+  @authorsaddresses{}
 }|
 
  @history[#:added "1.26"]}

--- a/scribble-doc/scribblings/scribble/acmart.scrbl
+++ b/scribble-doc/scribblings/scribble/acmart.scrbl
@@ -205,8 +205,8 @@ screen version of the image links to the badge authority.
 
 @defproc[(authorsaddresses [addresses pre-content?] ...) block?]{
  Sets the text for the authors' addresses on the first page
- in some styles. By default this field is set to the authors'
- affiliation.
+ in some styles. By default this field is set to the authors
+ and their affiliation information.
 
  The @racket[addresses] parameter takes the address text. As a
  special case the empty list removes the addresses field entirely.

--- a/scribble-lib/scribble/acmart.rkt
+++ b/scribble-lib/scribble/acmart.rkt
@@ -45,6 +45,10 @@
                #:email (or/c pre-content? email? (listof email?) #f))
               #:rest (listof pre-content?)
               block?)]
+ [authorsaddresses (->* ()
+                        ()
+                        #:rest (listof pre-content?)
+                        block?)]
  [institution (->* ()
                    (#:departments (listof (or/c pre-content? institution?)))
                    #:rest pre-content?
@@ -282,7 +286,13 @@
                                                   [else
                                                    (for/list ([e (in-list email)])
                                                      (convert-email e))]))))))))
-  
+
+(define (authorsaddresses . content)
+  (make-paragraph
+   (make-style 'pretitle command-props)
+   (make-element (make-style "authorsaddresses" command-props)
+                 (decode-content content))))
+
 (define (institution #:departments [departments '()]
                      . name)
   (author-institution name departments))


### PR DESCRIPTION
This was added in a recent version of the acmart style and is
required to set (or remove) the addresses field at the bottom of
the first page in some styles.