### PR TITLE
doc: example include-section for scribble/lp2

### DIFF
--- a/scribble-doc/scribblings/scribble/lp.scrbl
+++ b/scribble-doc/scribblings/scribble/lp.scrbl
@@ -69,6 +69,15 @@ a @racket[doc] submodule that is expanded (so that the content is
 effectively re-expanded). The @racketidfont{doc} submodule is declared
 with @racket[module*].
 
+To include a @racketmodname[scribble/lp2] document named
+ @filepath{file.scrbl} into another Scribble document,
+ import the @racketidfont{doc} submodule:
+
+@codeblock[#:keep-lang-line? #false]|{
+  #lang scribble/manual
+  @include-section[(submod "file.scrbl" doc)]
+}|
+
 @history[#:added "1.8"
          #:changed "1.17" @elem{Declared the @racketidfont{doc} submodule with
                                 @racket[module*] instead of @racket[module].}]
@@ -127,8 +136,8 @@ used.
 @defmodule[scribble/lp-include]{The
 @racketmodname[scribble/lp-include] library is normally used within a
 Scribble document---that is, a module that starts with something like
-@racket[#, @hash-lang[] @racketmodname[scribble/base]] or @racket[#, @hash-lang[]
-@racketmodname[scribble/manual]], instead of @racket[#, @hash-lang[] @racketmodname[racket]].}
+@hash-lang[] @racketmodname[scribble/base] or @hash-lang[] @racketmodname[scribble/manual],
+instead of @hash-lang[] @racketmodname[racket].}
 
 @defform[(lp-include filename)]{
 Includes the source of @racket[filename] as the typeset version of the literate

--- a/scribble-doc/scribblings/scribble/manual.scrbl
+++ b/scribble-doc/scribblings/scribble/manual.scrbl
@@ -106,7 +106,7 @@ for-label bindings in the lexical environment of the syntax object
 provided by @racket[context-expr]. The default @racket[context-expr]
 has the same lexical context as the first @racket[str-expr].
 When @racket[line-number-expr] is true, line number is enabled starting 
-from @racket[line-number-expr], and @racket[line-number-sep] controls
+from @racket[line-number-expr], and @racket[line-number-sep-expr] controls
 the separation (in spaces; defaults to 1) between the line numbers and
 code.
 


### PR DESCRIPTION
EDIT resolved
~Is it possible (without using `verbatim`) to make the `racketblock` render exactly as:~

```
@include-section[(submod "file.scrbl" doc)]
```

Screenshots:
![screen shot 2017-11-29 at 23 12 17](https://user-images.githubusercontent.com/1731829/33412527-dbe293d6-d559-11e7-8c00-30d8ef54735a.png)

![screen shot 2017-11-29 at 23 12 25](https://user-images.githubusercontent.com/1731829/33412535-e2399c34-d559-11e7-98ac-4e898872aadd.png)
