### PR TITLE
Provide special?

### DIFF
--- a/scribble-text-lib/scribble/text/output.rkt
+++ b/scribble-text-lib/scribble/text/output.rkt
@@ -4,6 +4,7 @@
 
 (provide
  outputable/c
+ special?
  (contract-out 
   [output (->* (outputable/c) (output-port?) void?)]))
 ;; See also `provide-special` below


### PR DESCRIPTION
For programs using scribble/html/xml to represent html, the predicate used to represent entities were missing.
The contract outputable can not be used instead since it has been effectively be removed.