### PR TITLE
defthing: use #:id expression instead of 'id'

### DIFF
--- a/scribble-lib/scribble/private/manual-proc.rkt
+++ b/scribble-lib/scribble/private/manual-proc.rkt
@@ -1039,12 +1039,13 @@
      #'(with-togetherable-racket-variables
         ()
         ()
-        (*defthing kind.kind
-                   lt.expr
-                   (list (or id-expr (quote-syntax/loc id))) (list 'id) #f
-                   (list (racketblock0 result))
-                   (lambda () (list desc ...))
-                   (list (result-value value.value))))]))
+        (let ([id-val id-expr])
+          (*defthing kind.kind
+                     lt.expr
+                     (list (or id-val (quote-syntax/loc id))) (list (or id-val 'id)) #f
+                     (list (racketblock0 result))
+                     (lambda () (list desc ...))
+                     (list (result-value value.value)))))]))
 
 (define-syntax (defthing* stx)
   (syntax-parse stx


### PR DESCRIPTION
Change implementation of `defthing` so that if the user gives an `id-expr` via the `#:id` keyword, then `defthing` never uses the default `id`.

I think this is right, based on the docs. But maybe the docs should change.

cc @dedbox for reporting this

- - -

Example program:

```
#lang scribble/manual

@defthing[#:id (datum->syntax #f 'foo) dont-use integer?]{
  Something
}
```

Before this PR:
![screen shot 2018-02-04 at 16 50 08](https://user-images.githubusercontent.com/1731829/35782688-d89eb534-09c9-11e8-8e58-4b68a05a4116.png)

After this PR:
![screen shot 2018-02-04 at 16 50 18](https://user-images.githubusercontent.com/1731829/35782691-df44a0ce-09c9-11e8-9ae4-e0874878fb7f.png)

