### PR TITLE
point send-main-page to racket website when docs not found

### DIFF
--- a/scribble-lib/help/search.rkt
+++ b/scribble-lib/help/search.rkt
@@ -39,11 +39,16 @@
                                          (string->url
                                           (format "q?~a" query)))
                                         null))])))]
-   [else
-    (let* ([path (build-path (find-user-doc-dir) sub)]
-           [path (if (file-exists? path) path (build-path (find-doc-dir) sub))])
-      (notify path)
-      (send-url/file path #:fragment fragment #:query query))]))
+    [else
+      (let* ([path (build-path (find-user-doc-dir) sub)]
+             [path (if (file-exists? path) path (build-path (find-doc-dir) sub))])
+        (notify path)
+        (if (file-exists? path)
+          (send-url/file path #:fragment fragment #:query query)
+          (let ([part (lambda (pfx x) (if x (string-append pfx x) ""))])
+            (send-url (string-append
+                        "https://docs.racket-lang.org/"
+                        sub (part "#" fragment) (part "?" query))))))]))
 
 ;; This is an example of changing this code to use the online manuals.
 ;; Normally, it's better to set `doc-open-url` in "etc/config.rktd",


### PR DESCRIPTION
Currently, `raco docs` will open a web browser to a "file not found" page when docs are not installed and `doc-open-url` is not set in `config.rktd`.  This can be an issue for linux distributions which package the docs separately from racket itself, because modifying `config.rktd` dynamically as part of the install process could overwrite a user's preference.

This PR fixes the issue by pointing `send-main-page` to "https://docs.racket-lang.org/" when docs can not be found.