### PR TITLE
Provide special? from scribble/text/output

### DIFF
--- a/scribble-text-lib/scribble/text/output.rkt
+++ b/scribble-text-lib/scribble/text/output.rkt
@@ -3,6 +3,7 @@
          racket/contract/base)
 
 (provide
+ special?
  outputable/c
  (contract-out 
   [output (->* (outputable/c) (output-port?) void?)]))


### PR DESCRIPTION
Specials are used to represent entities such as nbsp, so the predicate special? needs to be exported
for users of scribble/text to recognize such elements. It is no longer possible to use the contract - since
the contract has effectively been bypassed.