### PR TITLE
lncs: add basic .css file

### DIFF
--- a/scribble-lib/scribble/lncs/lncs.css
+++ b/scribble-lib/scribble/lncs/lncs.css
@@ -1,4 +1,4 @@
-/* Support for styles in scribble/acmart */
+/* Support for styles in scribble/lncs */
 
 .SAuthorPlace, .SAuthorEmail,
 .SConferenceInfo, .SCopyrightYear, .SCopyrightData,


### PR DESCRIPTION
Copy `scribble/sigplan`'s style file to `scribble/lncs` because the HTML renderer expects to find an `lncs.css` file.

Closes https://github.com/racket/racket/issues/2010