### PR TITLE
acmart: avoid mathabx '\bigtimes'

### DIFF
--- a/scribble-lib/scribble/acmart/acmart-load.tex
+++ b/scribble-lib/scribble/acmart/acmart-load.tex
@@ -3,6 +3,15 @@
 % Avoid package option conflict
 \renewcommand\packageColor\relax
 \renewcommand\packageTocstyle\relax
+\renewcommand\packageMathabx{
+  \ifx\bigtimes\undefined
+    \usepackage{mathabx}
+  \else
+    \let\newtxmathbigtimes=\bigtimes
+    \let\bigtimes\undefined
+    \usepackage{mathabx}
+    \let\bigtimes=\newtxmathbigtimes
+  \fi}
 \let\Footnote\undefined
 \let\captionwidth\undefined
 \renewcommand{\renewrmdefault}{}

--- a/scribble-lib/scribble/acmart/acmart-load.tex
+++ b/scribble-lib/scribble/acmart/acmart-load.tex
@@ -3,15 +3,8 @@
 % Avoid package option conflict
 \renewcommand\packageColor\relax
 \renewcommand\packageTocstyle\relax
-\renewcommand\packageMathabx{
-  \ifx\bigtimes\undefined
-    \usepackage{mathabx}
-  \else
-    \let\newtxmathbigtimes=\bigtimes
-    \let\bigtimes\undefined
-    \usepackage{mathabx}
-    \let\bigtimes=\newtxmathbigtimes
-  \fi}
+\renewcommand\packageMathabx{\ifx\bigtimes\undefined \usepackage{mathabx} \else \relax \fi}
+% Both 'mathabx' and 'newtxmath' (required by the 'acmart' class) define a '\bigtimes' command. 
 \let\Footnote\undefined
 \let\captionwidth\undefined
 \renewcommand{\renewrmdefault}{}


### PR DESCRIPTION
The [`acmart`](https://www.acm.org/binaries/content/assets/publications/consolidated-tex-template/acmart.pdf) LaTeX class uses the `newtxmath` package, if available. The `newtxmath` package provides a `\bigtimes` command.

Scribble's `scribble-load.tex` uses the `mathabx` package by default, which also provides a `\bigtimes` command. This means that `scribble/acmart` documents don't work on systems with `newtxmath` installed. Example:

```
#lang scribble/acmart
@title{Title}
@author{Author}
;; raco scribble --pdf file.scrbl ==> BOOM!
```

Since `scribble/acmart` documents should use the symbols that `acmart` provides, this pull request hides the `mathabx` version of `\bigtimes`

Thank you @pnwamk for reporting and thank you @LeifAndersen for helping debug

TODO:
- [X] test on TexLive 2017 (with `newtxmath`)
- [x] text on TexLive 2015 (without `newtxmath`)