### PR TITLE
add optional #:note to 'bib-entry'

### DIFF
--- a/scribble-doc/scribblings/scribble/manual.scrbl
+++ b/scribble-doc/scribblings/scribble/manual.scrbl
@@ -1909,7 +1909,8 @@ order as given.}
                     [#:author author (or/c #f pre-content?) #f]
                     [#:location location (or/c #f pre-content?) #f]
                     [#:date date (or/c #f pre-content?) #f] 
-                    [#:url url (or/c #f pre-content?) #f])
+                    [#:url url (or/c #f pre-content?) #f]
+                    [#:note note (or/c #f pre-content?) #f])
          bib-entry?]{
 
 Creates a bibliography entry. The @racket[key] is used to refer to the
@@ -1942,7 +1943,12 @@ the entry:
        bibliography using @racket[tt] and hyperlinked, or it is
        omitted if given as @racket[#f].}
 
-]}
+ @item{@racket[note] is an optional comment about the work. It is typeset
+       in the bibliography as given, and appears directly after the date
+       (or URL, if given) with no space or punctuation in between.}
+]
+
+@history[#:changed "1.29" @elem{Added the @racket[#:note] option.}]}
 
 
 @defproc[(bib-entry? [v any/c]) boolean?]{

--- a/scribble-lib/scribble/private/manual-bib.rkt
+++ b/scribble-lib/scribble/private/manual-bib.rkt
@@ -17,7 +17,8 @@
              (#:is-book? boolean? #:author (or/c false/c pre-content?) 
                          #:location (or/c false/c pre-content?) 
                          #:date (or/c false/c pre-content?) 
-                         #:url (or/c false/c pre-content?))
+                         #:url (or/c false/c pre-content?)
+                         #:note (or/c false/c pre-content?))
              . ->* .
              a-bib-entry?)]
  [rename a-bib-entry? bib-entry? (any/c . -> . boolean?)]
@@ -46,7 +47,8 @@
                    #:author [author #f]
                    #:location [location #f]
                    #:date [date #f]
-                   #:url [url #f])
+                   #:url [url #f]
+                   #:note [note #f])
   (make-a-bib-entry
    key
    (make-element
@@ -63,7 +65,8 @@
        `(" " ,@(decode-content (list location)) ,(if date "," "."))
        null)
      (if date `(" " ,@(decode-content (list date)) ".") null)
-     (if url `(" " ,(link url (tt url))) null)))))
+     (if url `(" " ,(link url (tt url))) null)
+     (if note (decode-content (list note)) null)))))
 
 (define-on-demand bib-style (make-style "RBibliography" scheme-properties))
 


### PR DESCRIPTION
Add an optional argument to bib-entry to typeset a comment directly
after a citation --- with no punctuation between the end of the citation
and start of the comment.

Example uses:

- making an annotated bibliography, with an element that appears just
  below each citation

- adding "accessed" dates just after a URL, e.g.
  `(bib-entry .... #:url "...." #:note ", accessed 2018-06-14")`

Example document:

```
#lang scribble/manual
@title{Doc}

@(bibliography
   (bib-entry #:key "WT18"
              #:author "J. Wang and S. Z. Taylor"
              #:title "Parabolic Monoids and Concrete Galois Theory"
              #:location "Mathgen"
              #:date "2018"
              #:url "http://thatsmathematics.com/mathgen/"
              #:note ", accessed 2018-06-14")
   (bib-entry #:key "RJ18"
              #:author "D. Raman and R. A. Jones"
              #:title "On the Computation of Equations"
              #:location "Mathgen"
              #:date "2018"
              #:note @elem{@linebreak[]@linebreak[]@emph{Abstract:}
                Let @math{f_Z = U} be arbitrary. In @cite{WT18} the authors
                address the locality of hyper-holomorphic planes under the
                additional assumption that @math{Θ' = -1}. We show that there
                exists an one-to-one, stable, invertible and differentiable
                real, super-conditionally complete subset.}))
```

Output:

![screen shot 2018-06-14 at 14 39 39](https://user-images.githubusercontent.com/1731829/41431575-67feef82-6fe1-11e8-94c5-d0b75529d867.png)
