### PR TITLE
shortauthors

### DIFF
--- a/scribble-doc/scribblings/scribble/acmart.scrbl
+++ b/scribble-doc/scribblings/scribble/acmart.scrbl
@@ -223,6 +223,11 @@ screen version of the image links to the badge authority.
 
  @history[#:added "1.26"]}
 
+@defproc[(shortauthors [name pre-content?] ...) element?]{
+ Sets the text for the names of the authors in the running header.
+
+ @history[#:added "1.29"]}
+
 @deftogether[(
 @defproc[(terms [content pre-content?] ...) content?]
 @defproc[(keywords [content pre-content?] ...) content?]

--- a/scribble-doc/scribblings/scribble/acmart.scrbl
+++ b/scribble-doc/scribblings/scribble/acmart.scrbl
@@ -302,7 +302,7 @@ sponsors, @racket[name] is the name of the sponsor.  The
 @codeblock[#:keep-lang-line? #f]|{
   #lang scribble/acmart
   @acks{
-    The author thanks Benjamin Greenman for helpful comments on this
+    The author thanks Ben Greenman for helpful comments on this
     code. Financial support provided by the @grantsponsor["NSF7000"
     "National Scribble Foundation"]{http://racket-lang.org} under
     grant No.: @grantnum["NSF7000"]{867-5309}.}

--- a/scribble-doc/scribblings/scribble/core.scrbl
+++ b/scribble-doc/scribblings/scribble/core.scrbl
@@ -137,7 +137,7 @@ A @deftech{block} is either a @techlink{table}, an
                          output may be collapsed togther or replaced
                          with a line break. In the style
                          @racket['hspace], all text is converted to
-                         uncollapsable spaces that cannot be broken
+                         uncollapsible spaces that cannot be broken
                          across lines.}
 
                    @item{A symbol content is either @racket['mdash],

--- a/scribble-doc/scribblings/scribble/manual.scrbl
+++ b/scribble-doc/scribblings/scribble/manual.scrbl
@@ -263,7 +263,7 @@ produces
 (+ 1 (unsyntax (elem (racket x) (subscript "2"))))
 ]
 
-The @racket[escape-id] that defaults to @racket[unsyntax] is regonized via
+The @racket[escape-id] that defaults to @racket[unsyntax] is recognized via
 @racket[free-identifier=?], so a binding can hide the escape behavior:
 
 @RACKETBLOCK[

--- a/scribble-lib/info.rkt
+++ b/scribble-lib/info.rkt
@@ -23,4 +23,4 @@
 
 (define pkg-authors '(mflatt eli))
 
-(define version "1.28")
+(define version "1.29")

--- a/scribble-lib/scribble/acmart.rkt
+++ b/scribble-lib/scribble/acmart.rkt
@@ -50,6 +50,10 @@
                         ()
                         #:rest (listof pre-content?)
                         block?)]
+ [shortauthors (->* ()
+                    ()
+                    #:rest (listof pre-content?)
+                    element?)]
  [institution (->* ()
                    (#:departments (listof (or/c pre-content? institution?)))
                    #:rest pre-content?
@@ -309,6 +313,10 @@
    (make-style 'pretitle command-props)
    (make-element (make-style "authorsaddresses" command-props)
                  (decode-content content))))
+
+(define (shortauthors . content)
+  (make-element (make-style "Sshortauthors" command-props)
+                (decode-content content)))
 
 (define (institution #:departments [departments '()]
                      . name)

--- a/scribble-lib/scribble/acmart/acmart.tex
+++ b/scribble-lib/scribble/acmart/acmart.tex
@@ -1,4 +1,5 @@
-
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% BEGIN acmart/acmart.tex
 % Support for styles in scribble/acmart
 
 % These are replaced by scribble/acmart/style.tex,
@@ -26,3 +27,5 @@
 % Use ACM color; it would be better to use `citecolor` here somehow,
 % but I can't figure out how to do that
 \newcommand{\AutobibLink}[1]{\color{ACMPurple}{#1}}
+% END acmart/acmart.tex
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/scribble-lib/scribble/acmart/style.tex
+++ b/scribble-lib/scribble/acmart/style.tex
@@ -1,3 +1,5 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% BEGIN acmart/style.tex
 
 \renewcommand{\titleAndVersionAndAuthors}[3]{\title{#1}#3\maketitle}
 \renewcommand{\titleAndEmptyVersionAndAuthors}[3]{\titleAndVersionAndAuthors{#1}{#2}{#3}}
@@ -37,6 +39,8 @@
 
 \newcommand{\StitleShort}[2]{\title[#1]{#2}}
 
+\newcommand{\Sshortauthors}[1]{\renewcommand{\shortauthors}{#1}}
+
 \newcommand{\SacmBadgeRURL}[2]{\acmBadgeR[#1]{#2}}
 \newcommand{\SacmBadgeLURL}[2]{\acmBadgeL[#1]{#2}}
 
@@ -45,3 +49,5 @@
 \newcommand{\SreceivedStage}[2]{\received[#1]{#2}}
 
 \newcommand{\SccsdescNumber}[2]{\ccsdesc[#1]{#2}}
+% END acmart/style.tex
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Add a `@shortauthors{}` function to `scribble/acmart` and fix a few typos.