### PR TITLE
Synchronize the document of #:email in author with its actual the contract

### DIFF
--- a/scribble-doc/scribblings/scribble/acmart.scrbl
+++ b/scribble-doc/scribblings/scribble/acmart.scrbl
@@ -161,8 +161,8 @@ Specifies a subtitle.}
                         #f)
                   #f]
                  [#:email email
-                  (or/c pre-content? (listof pre-content?) #f)
-                  #f]
+                  (or/c pre-content? email? (listof email?))
+                  '()]
                  [name pre-content?] ...)
          block?]{
 

--- a/scribble-lib/scribble/acmart.rkt
+++ b/scribble-lib/scribble/acmart.rkt
@@ -43,7 +43,7 @@
                                    affiliation?
                                    (listof affiliation?)
                                    #f)
-               #:email (or/c pre-content? email? (listof email?) #f))
+               #:email (or/c pre-content? email? (listof email?)))
               #:rest (listof pre-content?)
               block?)]
  [authorsaddresses (->* ()


### PR DESCRIPTION
The `#:email` argument in `author` takes `(or/c pre-content? email? (listof email?) #f)` instead of `(or/c pre-content? (listof pre-content?))`. This also seems to be the case in the code. Plus, all `(listof pre-content?)` values are already a `pre-content?`.