### PR TITLE
Add email-string to typeset email with exact-chars

### DIFF
--- a/scribble-doc/scribblings/scribble/acmart.scrbl
+++ b/scribble-doc/scribblings/scribble/acmart.scrbl
@@ -168,6 +168,15 @@ Specifies a subtitle.}
 
  Specifies an author with an optional email address, affiliation, and/or orcid.
  
+@codeblock|{
+  #lang scribble/acmart
+  @title{Title}
+  @author["Unboxed Value"
+          #:email (list (email "user@server.com")
+                        (email-string "case--Int#@GHC.Prim.info"))]}
+
+  @abstract{abstracting abstract title}
+}|
 }
 
 @deftogether[(
@@ -197,9 +206,18 @@ screen version of the image links to the badge authority.
 
 }
 
-@defproc[(email [text pre-content?] ...)
-         email?]{
+@deftogether[(
+@defproc[(email [text pre-content?] ...) email?]
+@defproc[(email-string [text string?] ...) email?]
+)]{
  Creates an @racket[email?] object for use with @racket[author].
+
+ @racket[email-string] is like @racket[email]
+ except that @racket[email-string] only takes
+ @tech[#:doc '(lib "scribblings/reference/reference.scrbl") #:key "string"]{strings},
+ escapes all @tt{%} and @tt{#} characters
+ in the arguments and typesets the email address with the
+ @racket['exact-chars] style.
 }
 
 @defproc[(email? [email any/c]) boolean?]{

--- a/scribble-lib/scribble/acmart.rkt
+++ b/scribble-lib/scribble/acmart.rkt
@@ -3,6 +3,7 @@
 (require setup/collects
          racket/contract/base
          racket/list
+         racket/string
          scribble/core
          scribble/base
          scribble/decode
@@ -62,6 +63,9 @@
  [email (->* ()
              #:rest (listof pre-content?)
              email?)]
+ [email-string (->* ()
+                    #:rest (listof string?)
+                    email?)]
  [email? (-> any/c boolean?)]
  [affiliation (->* ()
                    (#:position (or/c pre-content? #f)
@@ -367,10 +371,28 @@
 (define (email . text)
   (author-email text))
 
+(define (email-string . text)
+  (define text-escaped
+    (for/list ([str (in-list text)])
+      (escape-email-string str)))
+  (author-email
+   (list
+    (make-element
+     (make-style #f '(exact-chars))
+     text-escaped))))
+
 (define (convert-email email)
   (make-element
    (make-style "SAuthorEmail" command-props)
    (decode-content (email-text email))))
+
+(define escape-email-map
+  #(("#" . "\\#")
+    ("%" . "\\%")))
+(define (escape-email-string str)
+  (for/fold ([str str])
+            ([escape-map (in-vector escape-email-map)])
+    (string-replace str (car escape-map) (cdr escape-map))))
 
 (define (affiliation #:position [position #f]
                      #:institution [institution #f]


### PR DESCRIPTION
Add the `email-string` function that

- Takes only `string?`s
- Escapes `%` and `#` (as discussed in #185)
- Typeset the email address using `exact-chars`
- Produce the result as a `email?`.