### PR TITLE
htmls: don't overwrite index.html

### DIFF
--- a/scribble-lib/scribble/html-render.rkt
+++ b/scribble-lib/scribble/html-render.rkt
@@ -1937,6 +1937,7 @@
     (define/override (start-collect ds fns ci)
       (parameterize ([current-part-files (make-hash)])
         (for-each (lambda (d fn)
+                    (check-duplicate-filename fn)
                     (parameterize ([collecting-sub
                                     (if (part-style? d 'non-toc)
                                         1


### PR DESCRIPTION
when rendering multiple html files to a directory `d`, add
`d/index.html` to the set of files-to-be-writted to avoid overwriting
the main index with a part that happens to have the same tag

fixes #194