### PR TITLE
Add block? contract to typeset-code

### DIFF
--- a/scribble-doc/scribblings/scribble/manual.scrbl
+++ b/scribble-doc/scribblings/scribble/manual.scrbl
@@ -184,7 +184,7 @@ produces the typeset result
                        [#:keep-lang-line? keep? any/c #t]
                        [#:line-numbers line-numbers (or/c #f exact-nonnegative-integer?) #f]
                        [#:line-number-sep line-number-sep exact-nonnegative-integer? 1]
-                       [#:block? block? #t]
+                       [#:block? block? any/c #t]
                        [strs string?] ...)
          block?]{
  A function-based version of @racket[codeblock], allowing you to compute the @racket[strs] arguments.


### PR DESCRIPTION
I think something should be said about what `block?` does but I am not comfortable enough with the scribble code to write it down.