### PR TITLE
make 'verbatim' suppress line breaks in LaTeX output

### DIFF
--- a/scribble-lib/scribble/scribble.tex
+++ b/scribble-lib/scribble/scribble.tex
@@ -388,7 +388,7 @@
 \newcommand{\Svcenter}[1]{$\vcenter{#1}$}
 
 % Verbatim
-\newenvironment{SVerbatim}{}{}
+\newenvironment{SVerbatim}{\let\Sscribtextttold\Scribtexttt\renewcommand{\Scribtexttt}[1]{\mbox{\Sscribtextttold{##1}}}}{}
 
 % Helper to work around a problem with "#"s for URLs within \href
 % within other macros:


### PR DESCRIPTION
by re-defining Scribtexttt within a LaTeX-level verbatim environment,
because that command is wrapped around each line of the output

cc @mflatt

context: <https://groups.google.com/d/msg/racket-users/Ylkbre0SdQc/ivgK3e2hAQAJ>