### PR TITLE
Add https://blog.racket-lang.org/2012/06/submodules.html as an example for in-source documentation

### DIFF
--- a/scribble-doc/scribblings/scribble/srcdoc.scrbl
+++ b/scribble-doc/scribblings/scribble/srcdoc.scrbl
@@ -26,7 +26,9 @@ same way that the module system keeps expansion-time code separate
 from run-time code, and documentation information is recorded in a
 submodule to be separately loadable from the enclosing module.
 
-For an example use, see the @filepath{file} collection's
+For an example use, see
+@hyperlink["https://blog.racket-lang.org/2012/06/submodules.html"]{this}
+post at @tt{blog.racket-lang.org} or the @filepath{file} collection's
 @filepath{gif.rkt} source file and the corresponding extraction in
 @filepath{scribblings/gif.scrbl}. As that example illustrates,
 starting the module declaration with


### PR DESCRIPTION
I couldn't locate gif.rkt in the `file' collection. Seeing a complete working example was helpful to get started. I think it will be as useful for other Racketeers (especially beginners like myself).

If gif.rkt is indeed gone due to refactorings, I guess the reference to it should be removed.