### PR TITLE
search box: change '"s" for search' behavior

### DIFF
--- a/scribble-lib/scribble/scribble-common.js
+++ b/scribble-lib/scribble/scribble-common.js
@@ -169,10 +169,10 @@ AddOnLoad(function(){
     indicator.style.display = "block";
   });
 
-// Pressing "S" focuses on the "...search manuals..." text field
+// Pressing "S" or "s" focuses on the "...search manuals..." text field
 AddOnLoad(function(){
-  window.addEventListener("keypress", function(event) {
-    if (event && event.charCode == 115 && event.target == document.body) {
+  window.addEventListener("keyup", function(event) {
+    if (event && (event.keyCode == 83 || event.keyCode == 115) && event.target == document.body) {
       var field = document.getElementsByClassName("searchbox")[0];
       field.focus();
     }


### PR DESCRIPTION
1. Focus on the search box for either "s" or "S"
   ... accepting only "s" makes sense to me, but the comment said it
   accepted "S" and well why not
2. Look for a "keyup" event instead of key press, so that pressing "s"
   ONLY focuses on the box and does not focus-and-write-the-letter-"s"

"keyup" events apparently don't have a useful `charCode` field so this
PR looks at the `keyCode` field instead

cc @iitalics 