### PR TITLE
Fix raised exception on erroneous thing-doc usage.

### DIFF
--- a/scribble-lib/scribble/srcdoc.rkt
+++ b/scribble-lib/scribble/srcdoc.rkt
@@ -577,7 +577,7 @@
       [(_ id contract desc)
        (begin
          (unless (identifier? #'id)
-           (raise-syntax-error 'parameter/doc 
+           (raise-syntax-error 'thing-doc
                                "expected an identifier"
                                stx
                                #'id))


### PR DESCRIPTION
As discussed on racket-users@, thing-doc provide form raises misleading message if id is not an identifier.