### PR TITLE
scribble/srcdoc: add `class*-doc` and `class-doc` provide forms

### DIFF
--- a/scribble-doc/scribblings/scribble/srcdoc.scrbl
+++ b/scribble-doc/scribblings/scribble/srcdoc.scrbl
@@ -180,6 +180,23 @@ See @racket[defform] for information on @racket[options],
 @history[#:added "1.6"]}
 
 
+@defform[(class*-doc id super (intf-id ...) pre-flow)]{
+
+Like @racket[proc-doc], but for class declarations that use @racket[class*].
+
+The @racket[id], @racket[super], and @racket[intf-id] expressions have the same
+meaning as in @racket[defclass].}
+
+
+@defform[(class-doc id super pre-flow)]{
+
+Like @racket[class*-doc], but for class declarations that use @racket[class]
+omitting @racket[interface-expr]s.
+
+The @racket[id], and @racket[super] expressions have the same meaning as in
+@racket[defclass].}
+
+
 @defform[(begin-for-doc form ...)]{
 
 Like to @racket[begin-for-syntax], but for documentation time instead

--- a/scribble-doc/scribblings/scribble/srcdoc.scrbl
+++ b/scribble-doc/scribblings/scribble/srcdoc.scrbl
@@ -185,7 +185,9 @@ See @racket[defform] for information on @racket[options],
 Like @racket[proc-doc], but for class declarations that use @racket[class*].
 
 The @racket[id], @racket[super], and @racket[intf-id] expressions have the same
-meaning as in @racket[defclass].}
+meaning as in @racket[defclass].
+
+@history[#:added "1.30"]}
 
 
 @defform[(class-doc id super pre-flow)]{
@@ -194,7 +196,9 @@ Like @racket[class*-doc], but for class declarations that use @racket[class]
 omitting @racket[interface-expr]s.
 
 The @racket[id], and @racket[super] expressions have the same meaning as in
-@racket[defclass].}
+@racket[defclass].
+
+@history[#:added "1.30"]}
 
 
 @defform[(begin-for-doc form ...)]{

--- a/scribble-lib/info.rkt
+++ b/scribble-lib/info.rkt
@@ -23,4 +23,4 @@
 
 (define pkg-authors '(mflatt eli))
 
-(define version "1.29")
+(define version "1.30")

--- a/scribble-lib/scribble/srcdoc.rkt
+++ b/scribble-lib/scribble/srcdoc.rkt
@@ -16,6 +16,8 @@
          struct-doc
          struct*-doc
          form-doc
+         class*-doc
+         class-doc
          generate-delayed-documents
          begin-for-doc)
 
@@ -660,6 +662,48 @@
               c.contracts-seq ...
               . desc)
           #'((only-in scribble/manual defform))
+          #'id))])))
+
+(define-provide/doc-transformer class*-doc
+  (lambda (stx)
+    (syntax-case stx ()
+      [(_ id super (intf-id ...) pre-flow)
+       (begin
+         (unless (identifier? #'id)
+           (raise-syntax-error 'class*-doc
+                               "expected an identifier"
+                               stx
+                               #'id))
+         (unless (identifier? #'super)
+           (raise-syntax-error 'class*-doc
+                               "expected super class identifier"
+                               stx
+                               #'id))
+         (values
+          #'[id class?]
+          #'(defclass id super (intf-id ...) . pre-flow)
+          #'((only-in scribble/manual defclass defconstructor defmethod this-obj))
+          #'id))])))
+
+(define-provide/doc-transformer class-doc
+  (lambda (stx)
+    (syntax-case stx ()
+      [(_ id super pre-flow)
+       (begin
+         (unless (identifier? #'id)
+           (raise-syntax-error 'class-doc
+                               "expected an identifier"
+                               stx
+                               #'id))
+         (unless (identifier? #'super)
+           (raise-syntax-error 'class-doc
+                               "expected super class identifier"
+                               stx
+                               #'id))
+         (values
+          #'[id class?]
+          #'(defclass id super () . pre-flow)
+          #'((only-in scribble/manual defclass defconstructor defmethod this-obj))
           #'id))])))
 
 (define-syntax (generate-delayed-documents stx)

--- a/scribble-lib/scribble/srcdoc.rkt
+++ b/scribble-lib/scribble/srcdoc.rkt
@@ -1,5 +1,6 @@
 #lang racket/base
 (require racket/contract/base
+         racket/class
          (for-syntax racket/base
                      racket/require-transform
                      racket/provide-transform

--- a/scribble-lib/scribble/srcdoc.rkt
+++ b/scribble-lib/scribble/srcdoc.rkt
@@ -577,7 +577,7 @@
       [(_ id contract desc)
        (begin
          (unless (identifier? #'id)
-           (raise-syntax-error 'parameter/doc 
+           (raise-syntax-error 'thing-doc
                                "expected an identifier"
                                stx
                                #'id))


### PR DESCRIPTION
There should probably be @history[#:added ...] added to both scribblings.