### PR TITLE
Make @emph nestable, logical markup

### DIFF
--- a/scribble-doc/scribblings/scribble/base.scrbl
+++ b/scribble-doc/scribblings/scribble/base.scrbl
@@ -467,7 +467,9 @@ gets progressively smaller.}
 gets progressively larger.}
 
 @defproc[(emph [pre-content pre-content?] ...) element?]{
-The same as @racket[italic].}
+Like @racket[elem], but emphasised. Typically, italics are used for
+emphasis. Uses of @racket[emph] can be nested; typically this causes
+the text to alternate between italic and upright.}
 
 @defproc[(literal [str string?] ...+) element?]{
 

--- a/scribble-lib/scribble/base.rkt
+++ b/scribble-lib/scribble/base.rkt
@@ -258,7 +258,7 @@
   (make-element 'larger (decode-content str)))
 
 (define (emph . str)
-  (make-element 'italic (decode-content str)))
+  (make-element 'emph (decode-content str)))
 
 (define (tt . str)
   (let* ([l (decode-content str)]

--- a/scribble-lib/scribble/html-render.rkt
+++ b/scribble-lib/scribble/html-render.rkt
@@ -1607,6 +1607,7 @@
        (cond
         [(symbol? name)
          (case name
+           [(emph) '([class "emph"])]
            [(italic) '([style "font-style: italic"])]
            [(bold) '([style "font-weight: bold"])]
            [(tt) '([class "stt"])]

--- a/scribble-lib/scribble/latex-render.rkt
+++ b/scribble-lib/scribble/latex-render.rkt
@@ -471,6 +471,7 @@
               (cond
                [(symbol? style-name)
                 (case style-name
+                  [(emph) (wrap e "emph" tt?)]
                   [(italic) (wrap e "textit" tt?)]
                   [(bold) (wrap e "textbf" tt?)]
                   [(tt) (wrap e "Scribtexttt" #t)]

--- a/scribble-lib/scribble/markdown-render.rkt
+++ b/scribble-lib/scribble/markdown-render.rkt
@@ -216,6 +216,9 @@
     (define (italic? i)
       (and (element? i) (eq? (element-style i) 'italic)))
 
+    (define (emph? i)
+      (and (element? i) (eq? (element-style i) 'emph)))
+
     (define (code? i)
       (and (element? i)
            (let ([s (element-style i)])
@@ -258,6 +261,12 @@
 
         [(and (italic? i) (not (in-italic?)) (not (in-code?)))
           (recurse-wrapped "_" in-italic?)]
+
+        [(and (emph? i) (not (in-code?)))
+         (display "​_") ;; zero-width space, underscore
+         (begin0
+             (super render-content i part ri)
+           (display "_​"))] ;; underscore, zero-width space
 
         [(and (preserve-spaces? i) (not (preserving-spaces?)))
           (parameterize ([preserving-spaces? #t])
@@ -378,4 +387,3 @@
             ([ptn (map car ptns&reps)]
              [rep (map cdr ptns&reps)])
     (regexp-replace* ptn str rep)))
-

--- a/scribble-lib/scribble/scribble.css
+++ b/scribble-lib/scribble/scribble.css
@@ -30,6 +30,26 @@
   font-weight: bold;
 }
 
+/* Emphasis: alternate italics and normal as we nest */
+.emph {
+  font-style: italic;
+}
+.emph .emph {
+  font-style: normal;
+}
+.emph .emph .emph {
+  font-style: italic;
+}
+.emph .emph .emph .emph {
+  font-style: normal;
+}
+.emph .emph .emph .emph .emph {
+  font-style: italic;
+}
+.emph .emph .emph .emph .emph .emph {
+  font-style: normal;
+}
+
 /* ---------------------------------------- */
 
 p, .SIntrapara {


### PR DESCRIPTION
Use \emph in the LaTeX renderer and CSS in the HTML renderer to make nested emphasis toggle between italics and upright.

The CSS for this is not very nice (the nesting is written out); it would be nicer if the proposed "toggle()" function were available.

Also, it would seem sensible to use `em` elements in HTML, but I can't work out how to generate those at the point where styles are dealt with.