### PR TITLE
autobib: fix author formatting (#216)

### DIFF
--- a/scribble-doc/scriblib/scribblings/autobib.scrbl
+++ b/scribble-doc/scriblib/scribblings/autobib.scrbl
@@ -1,5 +1,6 @@
 #lang scribble/manual
-@(require (for-label scribble/struct
+@(require (for-label scribble/core
+                     scribble/struct
                      scriblib/autobib
                      scheme/base
                      scheme/contract))
@@ -228,7 +229,7 @@ Both arguments are optional, but at least one must be supplied.}
 Combines elements to generate an element that is suitable for
 describing a technical report's location.}
 
-@defproc[(dissertation-location [#:institution institution edition any/c]
+@defproc[(dissertation-location [#:institution institution any/c]
                                 [#:degree degree any/c "PhD"])
          element?]{
 
@@ -264,7 +265,7 @@ alphabetized appropriately. Any of @racket[name] or @racket[names]
 that are strings are
 parsed in the same way as by @racket[make-bib].}
 
-@defproc[(org-author-name [name any/c]) element?]{
+@defproc[(org-author-name [name (or/c element? string?)]) element?]{
 
 Converts an element for an organization name to one suitable for use
 as a bib-value author.}
@@ -275,7 +276,7 @@ Generates an element that is suitable for use as a ``others'' author.
 When combined with another author element via @racket[authors], the
 one created by @racket[other-authors] renders as ``et al.''}
 
-@defproc[(editor [name name/c]) element?]{
+@defproc[(editor [name (or/c element? string?)]) element?]{
 
 Takes an author-name element and create one that represents the editor
 of a collection. If a @racket[name] is a string, it is parsed in the

--- a/scribble-lib/scriblib/autobib.rkt
+++ b/scribble-lib/scriblib/autobib.rkt
@@ -621,7 +621,7 @@
 
 (define (authors name . names*)
   (define names (map parse-author (cons name names*)))
-  (define slash-names (string-join (map author-element-names names) " / "))
+  (define slash-names (string-join (map (compose1 content->string author-element-names) names) " / "))
   (define cite
     (case (length names)
       [(1) (author-element-cite (car names))]

--- a/scribble-test/tests/scriblib/autobib.rkt
+++ b/scribble-test/tests/scriblib/autobib.rkt
@@ -55,7 +55,6 @@
   (check-equal? (book-location #:edition "4th")
                 (mk-bookloc-elem/ed "4th")))
 
-
 (test-case "techrpt-location"
   (check-not-exn
     (λ () (techrpt-location #:institution "MIT" #:number 'AIM-353)))
@@ -71,3 +70,31 @@
     (λ () (dissertation-location #:institution "Georgetown University" #:degree "BS")))
   (check-exn exn:fail:contract?
     (λ () (dissertation-location #:degree "PhD"))))
+
+(test-case "authors"
+  ;; Define authors, make a bibliography
+  ;; https://github.com/racket/scribble/issues/216
+
+  (check-not-exn
+    (lambda ()
+      (define-cite cite citet gen-bib)
+      (define x*
+        (map
+          cite
+          (list
+            (make-bib
+              #:title "Histoire d'une Montagne"
+              #:author (authors "Elisée Reclus"))
+            (make-bib
+              #:title "The Jeffersonians"
+              #:author (authors "Richard B. Morris" "James Leslie Woods"))
+            (make-bib
+              #:title "Lucifer Magazine"
+              #:author (authors "H.P. Blavatsky" (other-authors)))
+            (make-bib
+              #:title "Dean's Electronics"
+              #:author (authors (org-author-name "robco") (org-author-name (authors "industries"))
+                                (editor "mister") (editor (authors "crowley"))
+                                (other-authors))))))
+      (gen-bib))))
+


### PR DESCRIPTION
- fix #216 by coercing author-element data to a string, add tests
- doc edits:
  - import `scribble/core` to fix link to `content?`
  - fix typo in `dissertation-location`
  - replace unbound reference to `name/c` with a real contract