### PR TITLE
add package-source style property

### DIFF
--- a/scribble-doc/scribblings/scribble/core.scrbl
+++ b/scribble-doc/scribblings/scribble/core.scrbl
@@ -524,6 +524,11 @@ The recognized @tech{style properties} are as follows:
         module path plus a section-tag string, so that the user can
         create a reference to the section.}
 
+ @item{@racket[package-source] structure --- For HTML, provides a
+        URL for the part's source Scribble file. Clicking on an HTML section
+        title generated for the part or its sub-parts may show this URL so
+        that a user can suggest patches to the source code.}
+
  @item{@racket[link-render-style] structure --- Determines the default
        rendering of links to sections or other destinations within the
        section. See also @racket[link-element] and
@@ -1830,6 +1835,27 @@ clicking a title show cross-reference information.
          #:changed "1.9" @elem{Added @tt{x-source-pkg}.}]}
 
 
+@defstruct[package-source ([base url?] [subpath-target (or/c #f #t symbol?)])]{
+
+Used as a @tech{style property} to associate a URL with a part.
+Clicking on a section title within the part may show a URL to help
+readers find the Scribble source code of the part.
+
+More specifically, the section title is given the HTML attribute
+@tt{x-source-pkg-url} and the @racket[scribble/manual] style recognizes
+this tag to make the generated URL visible on click.
+
+If the @racket[_subpath-target] field is @racket[#true], then the base URL
+ may be extended with a module path to an enclosing part.
+If the @racket[_subpath-target] field is a symbol, then the base URL
+ may be extended with a query association from the symbol to a module path
+ (if the base URL contains an association, then it is extended).
+
+See also @secref{make-package-source}.
+
+@history[#:added "1.33"]}
+
+
 @defstruct[html-defaults ([prefix (or/c bytes? path-string? 
                                         (cons/c 'collects (listof bytes?)))]
                           [style (or/c bytes? path-string? 
@@ -1961,3 +1987,27 @@ arguments to the element's command in Latex output.}
 
  @history[#:added "1.20"]
 }
+
+@; ----------------------------------------
+
+@section[#:tag "make-package-source"]{Package Source Constructors}
+
+@defproc[(exact-source-url [url (or/c string? url?)]) package-source?]{
+  Similar to @racket[(package-source url #f)].
+}
+
+@defproc[(github-source-url [user (or/c symbol? string?)]
+                            [repo (or/c symbol? string?)]
+                            [#:path path (or/c #f symbol? string?) #f]
+                            [#:branch branch (or/c #f symbol? string?) #f]) package-source?]{
+  TODO
+}
+
+
+@defproc[(gitlab-source-url [user (or/c symbol? string?)]
+                            [repo (or/c symbol? string?)]
+                            [#:path path (or/c #f symbol? string?) #f]
+                            [#:branch branch (or/c #f symbol? string?) #f]) package-source?]{
+  TODO x
+}
+

--- a/scribble-lib/info.rkt
+++ b/scribble-lib/info.rkt
@@ -23,4 +23,4 @@
 
 (define pkg-authors '(mflatt eli))
 
-(define version "1.32")
+(define version "1.33")

--- a/scribble-lib/scribble/html-properties.rkt
+++ b/scribble-lib/scribble/html-properties.rkt
@@ -2,11 +2,13 @@
 (require "private/provide-structs.rkt"
          racket/contract/base
          xml/xexpr
+         net/url-string
          net/url-structs)
 
 (provide-structs
  [body-id ([value string?])]
  [document-source ([module-path module-path?])]
+ [package-source ([base url?] [subpath-target (or/c symbol? boolean?)])]
 
  [xexpr-property ([before xexpr/c] [after xexpr/c])]
  [hover-property ([text string?])]
@@ -31,3 +33,33 @@
 
  [head-extra ([xexpr xexpr/c])]
  [render-convertible-as ([types (listof (or/c 'png-bytes 'svg-bytes))])])
+
+
+;; Extra constructors for package-source struct
+
+(define (exact-source-url x)
+  (define u (if (url? x) x (string->url x)))
+  (package-source u #false))
+
+(define (github-source-url user repo #:path [path #f] #:branch [pre-branch #f])
+  (define branch (if pre-branch (format "#~a" pre-branch) ""))
+  (define u (string->url (format "https://github.com/~a/~a?path=~a~a" user repo (or path "") branch)))
+  (package-source u 'path))
+
+(define (gitlab-source-url user repo #:path [pre-path #f] #:branch [pre-branch #f])
+  (define branch (or pre-branch "master"))
+  (define path (if pre-path (format "/~a" pre-path) ""))
+  (define u (string->url (format "https://gitlab.com/~a/~a/blob/~a~a" user repo branch path)))
+  (package-source u #true))
+
+(define git-source-url/c
+  (->* [(or/c symbol? string?) (or/c symbol? string?)]
+       [#:path (or/c #f symbol? string?)
+        #:branch (or/c #f symbol? string?)]
+       package-source?))
+
+(provide
+  (contract-out
+    [exact-source-url (-> (or/c url? string?) package-source?)]
+    [github-source-url git-source-url/c]
+    [gitlab-source-url git-source-url/c]))

--- a/scribble-lib/scribble/manual-racket.js
+++ b/scribble-lib/scribble/manual-racket.js
@@ -18,6 +18,7 @@ AddOnLoad(function() {
 function AddPartTitleOnClick(elem) {
     var mod_path = elem.getAttribute("x-source-module");
     var tag = elem.getAttribute("x-part-tag");
+    var pkg_url = elem.getAttribute("x-source-pkg-url");
     if (mod_path && tag) {
         // Might not be present:
         var prefixes = elem.getAttribute("x-part-prefixes");
@@ -77,6 +78,20 @@ function AddPartTitleOnClick(elem) {
             info.appendChild(line1x);
         if (is_long)
             info.appendChild(line2);
+
+        /* Add url to the document source code */
+        if (pkg_url) {
+          info.appendChild(document.createTextNode("Document source "));
+          var url_line = document.createElement("div");
+          var a = document.createElement("a");
+          a.href = pkg_url;
+          a.style.whiteSpace = "nowrap";
+          a.appendChild(document.createTextNode(pkg_url));
+          add(url_line, "\xA0", "RktRdr");
+          url_line.appendChild(a);
+          info.appendChild(url_line);
+        }
+
 
         info.style.display = "none";
 


### PR DESCRIPTION
If a part has the `package-source` property, then attach a URL to the HTML output so that the manuals can show a link to the "Document source" for editing / pull-requesting.

For example:
![Screen Shot 2019-12-13 at 23 16 06](https://user-images.githubusercontent.com/1731829/70843234-f950af00-1dfc-11ea-9a8b-eae1a114f15d.png)

That picture came from this code:
```
@title[#:tag "top" #:style (make-style #f (list (github-source-url 'bennn 'with-cache)))]{with-cache}
```

- - -

Another example, using GitLab:
![Screen Shot 2019-12-13 at 23 17 08](https://user-images.githubusercontent.com/1731829/70843238-19806e00-1dfd-11ea-89cf-c5be12969210.png)

Source code:
```
@title[#:style (make-style #f (list (gitlab-source-url 'bengreenman 'pict-abbrevs)))]{Pict Abbrevs}
```

- - -

Both the above work very nicely because the source is a single file. If a document uses `include-section`, then sub-parts inherit the parent's URL.

For example these two links in the redex docs:
![Screen Shot 2019-12-13 at 23 18 25](https://user-images.githubusercontent.com/1731829/70843264-66fcdb00-1dfd-11ea-9cd0-0cd035729b8e.png)

Come from one line of code, but sadly point to the same source file:
```
@title[#:style (make-style #f (list (github-source-url 'racket 'redex #:path 'redex-doc)))]{Redex: Practical Semantics Engineering}
```

- - -

A sub-part can manually give a more specific URL:
![Screen Shot 2019-12-13 at 23 21 10](https://user-images.githubusercontent.com/1731829/70843278-acb9a380-1dfd-11ea-8fdc-07542eda55ea.png)


```
@title[#:style (make-style #f (list (exact-source-url "https://github.com/racket/redex?path=redex-doc/redex/scribblings/ref.scrbl")))]{The Redex Reference}
```

But I haven't figured out a nice way to infer a better URL.

And really, ideally, I'd like to put one base URL in the `scribblings` entry of an `info.rkt` and get precise URLs without any changes to the document. So, suggestions are definitely welcome.
