### PR TITLE
Fix the contracts on `exec`/`commandline` to match their behavior

### DIFF
--- a/scribble-doc/scribblings/scribble/manual.scrbl
+++ b/scribble-doc/scribblings/scribble/manual.scrbl
@@ -1714,9 +1714,8 @@ Typesets the given combination of a GUI's menu and item name.}
 @tech{decode}d @racket[pre-content] as a file name (e.g., in
 typewriter font and in quotes).}
 
-@defproc[(exec [pre-content pre-content?] ...) element?]{Typesets the
-@tech{decode}d @racket[pre-content] as a command line (e.g., in
-typewriter font).}
+@defproc[(exec [content content?] ...) element?]{Typesets the
+@racket[content] as a command line (e.g., in typewriter font).}
 
 @defproc[(envvar [pre-content pre-content?] ...) element?]{Typesets the given
 @tech{decode}d @racket[pre-content] as an environment variable (e.g.,
@@ -2028,7 +2027,7 @@ that is hyperlinked to an explanation.}
 
 @defthing[undefined-const element?]{Returns an element for @|undefined-const|.}
 
-@defproc[(commandline [pre-content pre-content?] ...) paragraph?]{Produces
+@defproc[(commandline [content content?] ...) paragraph?]{Produces
 an inset command-line example (e.g., in typewriter font).}
 
 @defproc[(inset-flow [pre-flow pre-flow?] ...) nested-flow?]{

--- a/scribble-lib/scribble/private/manual-style.rkt
+++ b/scribble-lib/scribble/private/manual-style.rkt
@@ -4,7 +4,7 @@
          "../base.rkt"
          (only-in "../basic.rkt" aux-elem itemize)
          "../scheme.rkt"
-         (only-in "../core.rkt" make-style plain
+         (only-in "../core.rkt" content? make-style plain
                   make-nested-flow nested-flow? box-mode box-mode*
                   [element? core:element?])
          "manual-utils.rkt"
@@ -31,7 +31,7 @@
 (provide-styling racketmodfont racketoutput
                  racketerror racketfont racketplainfont racketvalfont racketidfont racketvarfont
                  racketcommentfont racketparenfont racketkeywordfont racketmetafont
-                 onscreen defterm filepath exec envvar Flag DFlag PFlag DPFlag math
+                 onscreen defterm filepath envvar Flag DFlag PFlag DPFlag math
                  procedure
                  indexed-file indexed-envvar idefterm pidefterm)
 (provide
@@ -59,7 +59,8 @@
  [inset-flow (() () #:rest (listof pre-content?) . ->* . nested-flow?)]
  [litchar (() () #:rest (listof string?) . ->* . element?)]
  [t (() () #:rest (listof pre-content?) . ->* . paragraph?)]
- [commandline (() () #:rest (listof pre-content?) . ->* . paragraph?)]
+ [exec (() () #:rest (listof content?) . ->* . element?)]
+ [commandline (() () #:rest (listof content?) . ->* . paragraph?)]
  [menuitem (string? string? . -> . element?)])
 
 (define PLaneT (make-element "planetName" '("PLaneT")))


### PR DESCRIPTION
`exec` and `commandline` are documented as decoding their content, and they have contracts that suggest that they do, but in fact they do not. Whether originally intentional or not, this corrects the documentation and contracts to match their true behavior.