### PR TITLE
Provide a distinguished source when reading in `codeblock`.

### DIFF
--- a/scribble-lib/scribble/private/manual-code.rkt
+++ b/scribble-lib/scribble/private/manual-code.rkt
@@ -124,7 +124,9 @@
                           (loop (if (dont-stop? mode)
                                     (dont-stop-val mode)
                                     mode))))))]
-           [program-source 'prog]
+           ;; use a source that both identifies the original code
+           ;; and is unique wrt eq? as used below
+           [program-source (or context bstr)]
            [e (parameterize ([read-accept-reader #t])
                 ((or expand 
                      (lambda (stx) 


### PR DESCRIPTION
Closes racket/racket#3102.