### PR TITLE
use `aside` for `margin-note`

### DIFF
--- a/scribble-lib/scribble/base.rkt
+++ b/scribble-lib/scribble/base.rkt
@@ -676,7 +676,7 @@
                  null)
      (list
       (make-nested-flow
-       (make-style "refcontent" null)
+       (make-style "refcontent" (list (alt-tag "aside")))
        (decode-flow c)))))))
 
 (define (margin-note* #:left? [left? #f] . c)


### PR DESCRIPTION
address #205 
Note `aside` cannot be used for the inline version `margin-note*`