### PR TITLE
Fix #131: disallow bogus mode arguments and fix related bugs

### DIFF
--- a/scribble-doc/scribblings/scribble/manual.scrbl
+++ b/scribble-doc/scribblings/scribble/manual.scrbl
@@ -1609,14 +1609,15 @@ accepted and propagated to the superclass.}
               ([maybe-link code:blank
                            (code:line #:link-target? link-target?-expr)]
                [maybe-mode code:blank
+                           (code:line #:mode public)
+                           (code:line #:mode public-final)
                            (code:line #:mode override)
                            (code:line #:mode override-final)
-                           (code:line #:mode public-final)
                            (code:line #:mode augment)
                            (code:line #:mode augment-final)
-                           (code:line #:mode pubment)
                            (code:line #:mode extend)
-                           (code:line #:mode extend-final)])]{
+                           (code:line #:mode extend-final)
+                           (code:line #:mode pubment)])]{
 
 Like @racket[defproc], but for a method within a @racket[defclass] or
 @racket[definterface] body.
@@ -1626,7 +1627,10 @@ method from a superclass, and so on. (For these purposes, use
 @racket[#:mode override] when refining a method of an implemented
 interface.) The @racket[extend] mode is like @racket[override], but
 the description of the method should describe only extensions to the
-superclass implementation.}
+superclass implementation. When @racket[maybe-mode] is not supplied,
+it defaults to @racket[public].
+
+@history[#:changed "1.35" @elem{Added a check against invalid @racket[maybe-mode].}]}
 
 @defform[(defmethod* maybe-mode maybe-link
                      ([(id arg-spec ...)

--- a/scribble-lib/info.rkt
+++ b/scribble-lib/info.rkt
@@ -23,4 +23,4 @@
 
 (define pkg-authors '(mflatt eli))
 
-(define version "1.34")
+(define version "1.35")

--- a/scribble-lib/scribble/private/manual-class.rkt
+++ b/scribble-lib/scribble/private/manual-class.rkt
@@ -436,7 +436,12 @@
                           [(pubment)
                            #'((t "Refine this method with "
                                  (racket augment) "."))]
-                          [(override override-final extend augment)
+                          [(override
+                            override-final
+                            extend
+                            extend-final
+                            augment
+                            augment-final)
                            #`((t (case (syntax-e #'mode)
                                    [(override override-final) "Overrides "]
                                    [(extend extend-final) "Extends "]
@@ -444,7 +449,8 @@
                                  (*xmethod/super (quote-syntax/loc cname) 'name1)
                                  "."
                                  #,@(finality)))]
-                          [else null]))])
+                          [(public public-final) null]
+                          [else (raise-syntax-error #f "unrecognized mode" #'mode)]))])
          #'(make-meth '(name ...)
                       'mode
                       (lambda ()

--- a/scribble-lib/scribble/private/manual-class.rkt
+++ b/scribble-lib/scribble/private/manual-class.rkt
@@ -425,12 +425,12 @@
                    [name1 (car (syntax->list #'(name ...)))])
        (with-syntax ([(extra ...)
                       (let ([finality
-                             (lambda ()
+                             (lambda (prefix)
                                (case (syntax-e #'mode)
                                  [(override-final public-final extend-final)
-                                  #'(" This method is final, so it cannot be overiddden.")]
+                                  #`(#,prefix "This method is final, so it cannot be overiddden.")]
                                  [(augment-final)
-                                  #'(" This method is final, so it cannot be augmented.")]
+                                  #`(#,prefix "This method is final, so it cannot be augmented.")]
                                  [else null]))])
                         (case (syntax-e #'mode)
                           [(pubment)
@@ -448,8 +448,8 @@
                                      [(augment augment-final) "Augments "])
                                  (*xmethod/super (quote-syntax/loc cname) 'name1)
                                  "."
-                                 #,@(finality)))]
-                          [(public public-final) null]
+                                 #,@(finality " ")))]
+                          [(public public-final) #`((t #,@(finality "")))]
                           [else (raise-syntax-error #f "unrecognized mode" #'mode)]))])
          #'(make-meth '(name ...)
                       'mode

--- a/scribble-lib/scribble/private/manual-class.rkt
+++ b/scribble-lib/scribble/private/manual-class.rkt
@@ -442,10 +442,10 @@
                             extend-final
                             augment
                             augment-final)
-                           #`((t (case (syntax-e #'mode)
-                                   [(override override-final) "Overrides "]
-                                   [(extend extend-final) "Extends "]
-                                   [(augment augment-final) "Augments "])
+                           #`((t #,(case (syntax-e #'mode)
+                                     [(override override-final) "Overrides "]
+                                     [(extend extend-final) "Extends "]
+                                     [(augment augment-final) "Augments "])
                                  (*xmethod/super (quote-syntax/loc cname) 'name1)
                                  "."
                                  #,@(finality)))]


### PR DESCRIPTION
- Raise a syntax error when bogus mode arguments are given.
  Note that https://github.com/racket/gui/pull/193 must be merged first.
- Fix a bug where `extend-final`, `augment-final`, and `public-final` are not recognized
- Document the `public` mode which was already supported but not
  documented.
- Clarify the default mode when `maybe-mode` is not given.