### PR TITLE
make the danger symbol (⚠ U+26A0) work in the latex backend

### DIFF
--- a/scribble-lib/scribble/latex-render.rkt
+++ b/scribble-lib/scribble/latex-render.rkt
@@ -1321,6 +1321,7 @@
                                 [(#\⟜) "$\\multimapinv$"]
                                 [(#\⅋) "$\\invamp$"]
                                 [(#\□) "$\\square$"]
+                                [(#\⚠) "{\\fontencoding{U}\\fontfamily{futs}\\selectfont\\char 66\\relax}"]
                                 [else
                                  (cond
                                   [(char<=? #\uAC00 c #\uD7AF) ; Korean Hangul


### PR DESCRIPTION
using one of the approaches found here
https://tex.stackexchange.com/questions/159669/how-to-print-a-warning-sign-triangle-with-exclamation-point

This fixes https://github.com/Metaxal/quickscript/issues/31 but I'm not sure if it is the best way.