### PR TITLE
Improve tech normalization of plural words

### DIFF
--- a/scribble-doc/scribblings/scribble/manual.scrbl
+++ b/scribble-doc/scribblings/scribble/manual.scrbl
@@ -1791,7 +1791,10 @@ normalized as follows:
 
  @item{A trailing ``ies'' is replaced by ``y''.}
 
- @item{A trailing ``s'' is removed.}
+ @item{A trailing ``es'' is removed if it was preceded by an ``s'', ``x'',
+   ``z'', ``ch'', or an ``sh''.}
+
+ @item{A trailing ``s'' is removed if it was not preceded by an ``s''.}
 
  @item{Consecutive hyphens and whitespaces are all replaced by a
        single space.}

--- a/scribble-lib/scribble/private/manual-tech.rkt
+++ b/scribble-lib/scribble/private/manual-tech.rkt
@@ -1,4 +1,4 @@
-#lang scheme/base
+#lang racket/base
 (require racket/contract/base
          "../decode.rkt"
          "../struct.rkt"


### PR DESCRIPTION
This pull request adjusts the behavior of `@tech{}` to better handle normalizing plural words to their singular forms. Specifically, it adds a rule to strip a trailing "es" in some circumstances and to **not** strip a trailing "s" if the last two letters of the term are "ss". I wanted this because `@tech{syntax class}` and `@tech{syntax classes}` currently normalize to `syntax clas` and `syntax classe` respectively.