### PR TITLE
Add racketoptionalfont

### DIFF
--- a/scribble-doc/scribblings/scribble/demo-manual.scrbl
+++ b/scribble-doc/scribblings/scribble/demo-manual.scrbl
@@ -8,10 +8,6 @@
 
 @(define css tt)
 
-@(define-syntax (opt-example stx)
-  ;; A #\? 'paren-shape value triggers RktOpt:
-   #`@racket[#,(syntax-property #'(in-example) 'paren-shape '#\?)])
-
 @title{Manual All-Styles Document}
 
 @table-of-contents[]
@@ -76,7 +72,9 @@
 
  @item{@css{RktModLink} (a linked module reference): @racketmodname[racket/base]}
 
- @item{@css{RktOpt} (option-argument brackets): brackets in @opt-example[]}
+ @item{@css{RktOpt} (option-argument brackets): brackets in
+
+       @defproc[(f [x any/c 1]) any]}
 
  @item{@css{RktKw} (not normally used): @racketkeywordfont{example}}
 

--- a/scribble-doc/scribblings/scribble/manual.scrbl
+++ b/scribble-doc/scribblings/scribble/manual.scrbl
@@ -555,6 +555,11 @@ sub-form in a procedure being documented).}
 @defproc[(racketparenfont [pre-content pre-content?] ...) element?]{Like
 @racket[racketplainfont], but colored like parentheses.}
 
+@defproc[(racketoptionalfont [pre-content pre-content?] ...) element?]{Like
+@racket[racketplainfont], but colored as optional.
+@history[#:added "1.36"]
+}
+
 @defproc[(racketmetafont [pre-content pre-content?] ...) element?]{Like
 @racket[racketplainfont], but colored as meta-syntax, such as backquote or
 unquote.}
@@ -596,6 +601,7 @@ in a form definition.}
 @defproc[(schemevarfont [pre-content pre-content?] ...) element?]
 @defproc[(schemekeywordfont [pre-content pre-content?] ...) element?]
 @defproc[(schemeparenfont [pre-content pre-content?] ...) element?]
+@defproc[(schemeoptionalfont [pre-content pre-content?] ...) element?]
 @defproc[(schememetafont [pre-content pre-content?] ...) element?]
 @defproc[(schemeerror [pre-content pre-content?] ...) element?]
 @defproc[(schememodfont [pre-content pre-content?] ...) element?]

--- a/scribble-lib/scribble/private/manual-proc.rkt
+++ b/scribble-lib/scribble/private/manual-proc.rkt
@@ -233,7 +233,7 @@
                     [(eq? (arg-id arg) '_...superclass-args...) (to-element (arg-id arg))]
                     [else (to-element (make-var-id (arg-id arg)))])]
            [e (if (arg-ends-optional? arg)
-                (make-element #f (list e "]"))
+                (make-element #f (list e (racketoptionalfont "]")))
                 e)]
            [num-closers (- (arg-depth arg) next-depth)]
            [e (if (zero? num-closers)
@@ -241,7 +241,7 @@
                 (make-element
                  #f (list e (make-closers num-closers))))])
       (if (and show-opt-start? (arg-starts-optional? arg))
-        (make-element #f (list "[" e))
+        (make-element #f (list (racketoptionalfont "[") e))
         e)))
   (define (prototype-depth p)
     (let loop ([p (car p)])
@@ -511,7 +511,7 @@
                    (if one-ok?
                        (list*
                         (if (arg-starts-optional? (car args))
-                            (to-flow (make-element #f (list spacer "[")))
+                            (to-flow (make-element #f (list spacer (racketoptionalfont "["))))
                             flow-spacer)
                         (to-flow ((arg->elem #f) (car args) (next-args-depth (cdr args))))
                         not-end)
@@ -530,7 +530,7 @@
                                 (flow-spacer/n 3)
                                 flow-spacer)
                             (if (arg-starts-optional? (car args))
-                                (to-flow (make-element #f (list spacer "[")))
+                                (to-flow (make-element #f (list spacer (racketoptionalfont "["))))
                                 flow-spacer)
                             (let ([a ((arg->elem #f) (car args) (next-args-depth (cdr args)))]
                                   [next (if dots-next?

--- a/scribble-lib/scribble/private/manual-style.rkt
+++ b/scribble-lib/scribble/private/manual-style.rkt
@@ -30,7 +30,7 @@
   (provide/contract [id styling-f/c] ...))
 (provide-styling racketmodfont racketoutput
                  racketerror racketfont racketplainfont racketvalfont racketidfont racketvarfont
-                 racketcommentfont racketparenfont racketkeywordfont racketmetafont
+                 racketcommentfont racketparenfont racketoptionalfont racketkeywordfont racketmetafont
                  onscreen defterm filepath envvar Flag DFlag PFlag DPFlag math
                  procedure
                  indexed-file indexed-envvar idefterm pidefterm)
@@ -47,6 +47,7 @@
                         [racketidfont schemeidfont]
                         [racketvarfont schemevarfont]
                         [racketparenfont schemeparenfont]
+                        [racketoptionalfont schemeoptionalfont]
                         [racketkeywordfont schemekeywordfont]
                         [racketmetafont schememetafont])
 
@@ -104,6 +105,8 @@
   (make-element variable-color (decode-content str)))
 (define (racketparenfont . str)
   (make-element paren-color (decode-content str)))
+(define (racketoptionalfont . str)
+  (make-element opt-color (decode-content str)))
 (define (racketmetafont . str)
   (make-element meta-color (decode-content str)))
 (define (racketcommentfont . str)

--- a/scribble-lib/scribble/racket.rkt
+++ b/scribble-lib/scribble/racket.rkt
@@ -606,9 +606,7 @@
                                    quote-depth)]
                   [p-color (if (positive? quote-depth) 
                                value-color
-                               (if (eq? sh #\?)
-                                   opt-color
-                                   paren-color))])
+                               paren-color)])
              (advance c init-line! srcless-step)
              (let ([quote-depth (if (struct-proxy? (syntax-e c))
                                     quote-depth
@@ -655,7 +653,7 @@
                    (set! src-col (+ src-col 2))))
                (unless (and expr? (zero? quote-depth))
                  (out (case sh
-                        [(#\[ #\?) "["]
+                        [(#\[) "["]
                         [(#\{) "{"]
                         [else "("])
                       p-color))
@@ -738,7 +736,7 @@
                                                                         srcless-step
                                                                         #f))]))
                (out (case sh
-                      [(#\[ #\?) "]"]
+                      [(#\[) "]"]
                       [(#\{) "}"]
                       [else ")"])
                     p-color)


### PR DESCRIPTION
Scribble used to support a custom style for optional brackets.
In particular, the optional brackets will be given the `'paren-shape`
of value `#\?`[1], and the CSS class `opt-color` will be tagged
to these brackets.

Later, Scribble supports the curry notation. Its implementation
no longer uses `'paren-shape` to indicate optional brackets.
Unfortunately, it also accidentally dropped the `opt-color` tagging[2].

This PR restores the original behavior by tagging the class
`opt-color` to optional brackets. It also adds `racketoptionalfont`
so that Scribble users can typeset optional brackets.
Lastly, it cleans up the code that supports the `'paren-shape` of value
`#\?`, since it is effectively a deadcode.

Note that this PR does _not_ change any CSS styling, so there's no
visible change. It would make CSS styling customization easier, however.

[1]: https://github.com/racket/scribble/commit/9b7993ea02d8f90f176e6305e8e1e7e46f5d4384#diff-017add06555fc85fa3ae5f27a3eb52cbR253
[2]: https://github.com/racket/scribble/commit/95ecb101d1cc61d212c4d520#diff-017add06555fc85fa3ae5f27a3eb52cbR879