### PR TITLE
Fix case sensitivity issues in bibtex

### DIFF
--- a/scribble-lib/scriblib/bibtex.rkt
+++ b/scribble-lib/scriblib/bibtex.rkt
@@ -83,7 +83,7 @@
       [typ
        (read-char ip)
        (slurp-whitespace ip)
-       (define label (read-until (λ (c) (char=? c #\,)) ip))
+       (define label (string-downcase (read-until (λ (c) (char=? c #\,)) ip)))
        (read-char ip)
        (define alist
          (let loop ()
@@ -110,7 +110,7 @@
                 [c
                  (perror ip 'read-entry "Parsing entry tag, expected =, got ~v; label is ~v; atag is ~v" c label atag)])])))
        (hash-set! ENTRY-DB label
-                  (hash-set alist 'type typ))]))
+                  (hash-set alist 'type (string-downcase typ)))]))
 
   (define (read-tag ip)
     (slurp-whitespace ip)
@@ -425,9 +425,9 @@
 
 (define (generate-bib db key)
   (match-define (bibdb raw bibs) db)
-  (hash-ref! bibs key
+  (hash-ref! bibs (string-downcase key)
              (λ ()
-               (define the-raw (hash-ref raw key (λ () (error 'bibtex "Unknown citation ~e" key))))
+               (define the-raw (hash-ref raw (string-downcase key) (λ () (error 'bibtex "Unknown citation ~e" key))))
                (define (raw-attr a [def #f])
                  (hash-ref the-raw a def))
                (define (raw-attr* a)

--- a/scribble-lib/scriblib/bibtex.rkt
+++ b/scribble-lib/scriblib/bibtex.rkt
@@ -197,22 +197,23 @@
       autobib-cite autobib-citet
       ~cite-id citet-id)))
 
+(define ((make-citer bibtex-db citer) f . r)
+  (apply citer
+         (filter-map
+          (λ (key)
+            (and (not (string=? "\n" key))
+                 (generate-bib bibtex-db key)))
+          (append-map (curry regexp-split #px"\\s+")
+                      (cons f r)))))
+
 (define-syntax-rule
   (define-bibtex-cite* bib-pth
     autobib-cite autobib-citet
     ~cite-id citet-id)
   (begin
     (define bibtex-db (path->bibdb bib-pth))
-    (define ((make-citer citer) f . r)
-      (apply citer
-             (filter-map
-              (λ (key)
-                (and (not (string=? "\n" key))
-                     (generate-bib bibtex-db key)))
-              (append-map (curry regexp-split #px"\\s+")
-                          (cons f r)))))
-    (define ~cite-id (make-citer autobib-cite))
-    (define citet-id (make-citer autobib-citet))))
+    (define ~cite-id (make-citer bibtex-db autobib-cite))
+    (define citet-id (make-citer bibtex-db autobib-citet))))
 
 (define (parse-author as)
   (and as

--- a/scribble-test/tests/scriblib/bibtex.number.txt
+++ b/scribble-test/tests/scriblib/bibtex.number.txt
@@ -6,3 +6,4 @@ Bibliography
    Python. Massachusetts Institute of Technology, 2004.                 
 [3]Sam Tobin-Hochstadt, Vincent St-Amour, Ryan Culpepper, Matthew Flatt,
    and Matthias Felleisen. Languages as Libraries. In Proc. PLDI, 2011. 
+[4]ZA ZAuThOr. StrIngS ArE TerriblE. 2000.                              

--- a/scribble-test/tests/scriblib/bibtex.rkt
+++ b/scribble-test/tests/scriblib/bibtex.rkt
@@ -73,4 +73,5 @@
               (λ (~cite-id citet-id)
                 (citet-id "salib:starkiller")
                 (citet-id "cryptoeprint:2000:067")
-                (citet-id "Tobin-Hochstadt:2011fk"))))
+                (citet-id "Tobin-Hochstadt:2011fk")
+                (citet-id "anannoyingkey"))))

--- a/scribble-test/tests/scriblib/example.bib
+++ b/scribble-test/tests/scriblib/example.bib
@@ -405,3 +405,8 @@ Book{landru21,
   month = "May",
   year = 2004
 }
+
+@MiSc{AnAnnoyingKeY,
+	Author = {ZA ZAuThOr},
+	Title = {StrIngS ArE TerriblE},
+	Year = {2000}}


### PR DESCRIPTION
bibtex is supposed to treat keys and labels as case insensitive, according to what I can find (http://maverick.inria.fr/~Xavier.Decoret/resources/xdkbibtex/bibtex_summary.html#stringdef). This was mostly true already, but labels and entry keys were not treated this way. This patch fixes it.