### PR TITLE
Attempt to fix verticle alignment of some boxes in latex backend

### DIFF
--- a/scribble-lib/scribble/latex-render.rkt
+++ b/scribble-lib/scribble/latex-render.rkt
@@ -282,7 +282,7 @@
                                      ((box-mode-selector as-box-mode) a)))
                               (style-properties
                                (paragraph-style p)))
-                       "hbox")]
+                       (format "adjustbox{valign=~a}" as-box-mode))]
                      [(eq? sn 'author) "SAuthor"]
                      [(eq? sn 'pretitle) #f]
                      [(eq? sn 'wraps) #f]

--- a/scribble-lib/scribble/scribble-load.tex
+++ b/scribble-lib/scribble/scribble-load.tex
@@ -16,3 +16,4 @@
 \newcommand{\doHypersetup}{\hypersetup{bookmarks=true,bookmarksopen=true,bookmarksnumbered=true}}
 \newcommand{\packageTocstyle}{\IfFileExists{tocstyle.sty}{\usepackage{tocstyle}\usetocstyle{standard}}{}}
 \newcommand{\packageCJK}{\IfFileExists{CJK.sty}{\usepackage{CJK}}{}}
+\newcommand{\packageAdjustbox}{\usepackage[export]{adjustbox}}

--- a/scribble-lib/scribble/scribble.tex
+++ b/scribble-lib/scribble/scribble.tex
@@ -14,6 +14,7 @@
 \doHypersetup
 \packageTocstyle
 \packageCJK
+\packageAdjustbox
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
This addresses #260 by providing a default box-adjuster. This requires an extra LaTeX package.

I'm not really sure this is a good solution, but I thought I'd offer a patch for experts to review. It might have unintended consequences if existing code was relying on ignoring the vertical alignment style property. The tests seem to pass, but it seems like a hard thing to write a test for.