### PR TITLE
Added support for latex escapes in bibtex titles and authors

### DIFF
--- a/scribble-test/tests/scriblib/bibtex.latex-escapes.txt
+++ b/scribble-test/tests/scriblib/bibtex.latex-escapes.txt
@@ -1,0 +1,6 @@
+Bibliography
+
+[1]Vı́ctor Braberman, Federico Fernández, Diego Garbervetsky, and Sergio
+   Yovine. Parametric prediction of heap memory requirements. In Proc.  
+   Proceedings of the 7th international symposium on Memory management, 
+   2008. http://doi.acm.org/10.1145/1375634.1375655                     

--- a/scribble-test/tests/scriblib/bibtex.rkt
+++ b/scribble-test/tests/scriblib/bibtex.rkt
@@ -10,6 +10,7 @@
 
 (define-runtime-path normal-expected-path "bibtex.normal.txt")
 (define-runtime-path number-expected-path "bibtex.number.txt")
+(define-runtime-path latex-escapes-path "bibtex.latex-escapes.txt")
 
 (define-syntax-rule (test-render* definer expected-path body generate-bibliography-id)
   (let ()
@@ -73,4 +74,7 @@
               (λ (~cite-id citet-id)
                 (citet-id "salib:starkiller")
                 (citet-id "cryptoeprint:2000:067")
-                (citet-id "Tobin-Hochstadt:2011fk"))))
+                (citet-id "Tobin-Hochstadt:2011fk")))
+ (test-render latex-escapes-path (#:style number-style)
+              (λ (~cite-id citet-id)
+                (citet-id "Braberman:2008:PPH:1375634.1375655"))))


### PR DESCRIPTION
This allows using certain escape sequences, such as \", in titles and authors of
bibtex files.
Titles are wrapped titles with 'exact-chars, so the set of escapes handled is
large.

A different method is used for author which basically convert certain well-known
escapes into Unicode.
This seems necessary to support parsing of author names.