### PR TITLE
Disable txfonts package in scribble/acmart

### DIFF
--- a/scribble-lib/scribble/acmart/acmart-load.tex
+++ b/scribble-lib/scribble/acmart/acmart-load.tex
@@ -5,6 +5,7 @@
 \renewcommand\packageTocstyle\relax
 \renewcommand\packageMathabx{\ifx\bigtimes\undefined \usepackage{mathabx} \else \relax \fi}
 % Both 'mathabx' and 'newtxmath' (required by the 'acmart' class) define a '\bigtimes' command. 
+\renewcommand\packageTxfonts\relax
 \let\Footnote\undefined
 \let\captionwidth\undefined
 \renewcommand{\renewrmdefault}{}


### PR DESCRIPTION
Commit c62d008cf include txfonts into the set of
default LaTeX packages. However, txfonts changes
the main font of the document, conflicting the
requirement of `scribble/acmart` articles.

We skip txfonts by setting `packageTxfonts` to nop.

Closes #271.