### PR TITLE
Replace txfonts by txmath

### DIFF
--- a/scribble-doc/scribblings/scribble/config.scrbl
+++ b/scribble-doc/scribblings/scribble/config.scrbl
@@ -524,9 +524,10 @@ style:
             @item{@ltxd[0]{packageHyperref}, defaults to @tt{\usepackage{hyperref}}}
             @item{@ltxd[0]{renewrmdefault}, defaults to @tt{\renewcommand{\rmdefault}{ptm}}}
             @item{@ltxd[0]{packageRelsize}, defaults to @tt{\usepackage{relsize}}}
+            @item{@ltxd[0]{packageAmsmath}, defaults to @tt{\usepackage{amsmath}}}
             @item{@ltxd[0]{packageMathabx}, defaults to @tt{\usepackage{mathabx}}}
-            @item{@ltxd[0]{packageWasysym}, defaults to @tt{\let\leftmoon\relax \let\rightmoon\relax \let\fullmoon\relax \let\newmoon\relax \let\diameter\relax \usepackage{wasysym}}}
-            @item{@ltxd[0]{packageTxfonts}, defaults to @tt{\usepackage{txfonts}}}
+            @item{@ltxd[0]{packageWasysym}, defaults to @tt{\let\leftmoon\relax \let\rightmoon\relax \let\fullmoon\relax \let\newmoon\relax \let\diameter\relax \usepackage[nointegrals]{wasysym}}}
+            @item{@ltxd[0]{packageTxfonts}, defaults to @tt{\let\widering\relax \usepackage{newtxmath}}}
             @item{@ltxd[0]{packageTextcomp}, defaults to @tt{\usepackage{textcomp}}}
             @item{@ltxd[0]{packageFramed}, defaults to @tt{\usepackage{framed}}}
             @item{@ltxd[0]{packageHyphenat}, defaults to @tt{\usepackage[htt]{hyphenat}}}
@@ -534,7 +535,15 @@ style:
             @item{@ltxd[0]{doHypersetup}, defaults to @tt{\hypersetup{bookmarks=true,bookmarksopen=true,bookmarksnumbered=true}}}
             @item{@ltxd[0]{packageTocstyle}, defaults to @tt{\IfFileExists{tocstyle.sty}{\usepackage{tocstyle}\usetocstyle{standard}}{}}}
             @item{@ltxd[0]{packageCJK}, defaults to @tt{\IfFileExists{CJK.sty}{\usepackage{CJK}}{}}}]
-  @history[#:changed "1.36" @list{Added @ltx{packageTxfonts}}]}
+  @history[#:changed "1.36" @list{Added @ltx{packageTxfonts}}]
+  @history[#:changed "1.37" @list{
+              Added @ltx{packageAmsmath};
+              changed @ltx{packageWasysym} to use @tt{nointegrals} option;
+              changed @ltx{packageTxfonts} to load @tt{newtxmath}.
+              Note that documents could look different due to
+              the new @tt{wasysym} option and the inclusion of @tt{newtxmath}.
+              See @hyperlink["https://github.com/racket/scribble/pull/274"]{
+              racket/scribble#274} for examples.}]}
 
  @item{@ltxd[0]{sectionNewpage} --- called before each top-level
        section starts; the default does nothing, while the

--- a/scribble-lib/info.rkt
+++ b/scribble-lib/info.rkt
@@ -23,4 +23,4 @@
 
 (define pkg-authors '(mflatt eli))
 
-(define version "1.36")
+(define version "1.37")

--- a/scribble-lib/scribble/scribble-load.tex
+++ b/scribble-lib/scribble/scribble-load.tex
@@ -3,12 +3,23 @@
 \newcommand{\packageHyperref}{\usepackage{hyperref}}
 \newcommand{\renewrmdefault}{\renewcommand{\rmdefault}{ptm}}
 \newcommand{\packageRelsize}{\usepackage{relsize}}
+% amsmath is required for the combination of {mathabx,
+% wasysym, newtxmath} to work. Otherwise, newtxmath
+% would load amsmath *after* mathabx and wasysym,
+% causing command redefinition issues.
+\newcommand{\packageAmsmath}{\usepackage{amsmath}}
 \newcommand{\packageMathabx}{\usepackage{mathabx}}
-% Avoid conflicts between "mathabx" and "wasysym":
+% Avoid conflicts between "mathabx" and "wasysym",
+% and between "wasysym" integrals and "amsmath" integrals (iint).
 \newcommand{\packageWasysym}{
   \let\leftmoon\relax \let\rightmoon\relax \let\fullmoon\relax \let\newmoon\relax \let\diameter\relax
-  \usepackage{wasysym}}
-\newcommand{\packageTxfonts}{\usepackage{txfonts}}
+  \usepackage[nointegrals]{wasysym}}
+% Both newtxmath and mathabx define the \widering command.
+% The only reason we choose the newtxmath version is that
+% acmart.cls is also using the one from newtxmath.
+\newcommand{\packageTxfonts}{
+  \let\widering\relax
+  \usepackage{newtxmath}}
 \newcommand{\packageTextcomp}{\usepackage{textcomp}}
 \newcommand{\packageFramed}{\usepackage{framed}}
 \newcommand{\packageHyphenat}{\usepackage[htt]{hyphenat}}

--- a/scribble-lib/scribble/scribble.tex
+++ b/scribble-lib/scribble/scribble.tex
@@ -4,6 +4,7 @@
 \packageHyperref
 \renewrmdefault
 \packageRelsize
+\packageAmsmath
 \packageMathabx
 \packageWasysym
 \packageTxfonts


### PR DESCRIPTION
Replace txfonts with newtxmath.

- The newtx package supersedes txfonts.

- As a side effect, we have to load amsmath
  as well and it has to be loaded before
  mathabx and wasysym.

- Add nointegrals option to wasysym to avoid conflicting amsmath.

- Pick the \widering from newtxmath over the \widering from mathabx.

For now, I have tried rendering PDFs for all languages but `scribble/jfp` in [High-Level Scribble API](https://docs.racket-lang.org/scribble/generic-prose.html) on the scribble files here: [scribble-langs-client.zip](https://github.com/racket/scribble/files/5248862/scribble-langs-client.zip).

The newtx package provides quite some [options](http://texdoc.net/texmf-dist/doc/fonts/newtx/newtxdoc.pdf) for selecting different styles of math symbols (e.g. `libertine`, `upint` or `smallerops`). I don't know which ones are more common. The decision is left to the user.
