### PR TITLE
Block scribble from changing the font to ptm in LNCS

### DIFF
--- a/scribble-lib/scribble/lncs/lang.rkt
+++ b/scribble-lib/scribble/lncs/lang.rkt
@@ -50,7 +50,8 @@
                                                     unicode-encoding-packages))
                 (scribble-file "lncs/style.tex")
                 (list cls-file)
-                #f))
+                #f
+                #:replacements (hash "scribble-load-replace.tex" (scribble-file "lncs/lncs-load.tex"))))
 
 (define lncs-extras
   (let ([abs (lambda (s)

--- a/scribble-lib/scribble/lncs/lncs-load.tex
+++ b/scribble-lib/scribble/lncs/lncs-load.tex
@@ -1,0 +1,14 @@
+% Scribble should not change the default font from CMR
+% to ptm for LNCS. See Guidelines for Authors of Papers
+% to be Published in Springer Computer Science Proceedings,
+% section 2.3, Fonts.
+%
+% IMPORTANT: the default package newtxmath *still*
+% changes the math font. If you want to disable it,
+% uncomment the next line
+% \renewcommand\packageTxfonts\relax
+% However, scribble would still generate LaTeX commands
+% that depend on newtxmath upon rendering symbols
+% \multimap, \multimapinv, \invamp and \square in
+% scribble-lib/scribble/latex-render.rkt.
+\renewcommand\renewrmdefault\relax


### PR DESCRIPTION
Block scribble from changing the default font to ptm for LNCS articles. Unfortunately, the math fonts are still incorrectly altered by newtxmath and I don't see a way to work around it.

Depends on #274.