### PR TITLE
Fix JS error when searchbox is not present

### DIFF
--- a/scribble-lib/scribble/html-render.rkt
+++ b/scribble-lib/scribble/html-render.rkt
@@ -228,6 +228,7 @@
        (input
         ([class "searchbox"]
          [style ,(sa "color: "dimcolor";")]
+         [id "searchbox"]
          [type "text"]
          [tabindex "1"]
          [value ,emptylabel]

--- a/scribble-lib/scribble/html-render.rkt
+++ b/scribble-lib/scribble/html-render.rkt
@@ -225,7 +225,6 @@
     `(form ([class "searchform"])
        (input
         ([class "searchbox"]
-         [style ,(sa "color: "dimcolor";")]
          [id "searchbox"]
          [type "text"]
          [tabindex "1"]

--- a/scribble-lib/scribble/scribble-common.js
+++ b/scribble-lib/scribble/scribble-common.js
@@ -173,8 +173,10 @@ AddOnLoad(function(){
 AddOnLoad(function(){
   window.addEventListener("keyup", function(event) {
     if (event && (event.keyCode == 83 || event.keyCode == 115) && event.target == document.body) {
-      var field = document.getElementsByClassName("searchbox")[0];
-      field.focus();
+      var searchBox = document.getElementById('searchbox');
+      if (searchBox) {
+        searchBox.focus();
+      }
     }
   }, false);
 });


### PR DESCRIPTION
When the search box is not present (e.g.,
https://docs.racket-lang.org/demo-m1/index.html),
pressing "S" will result in a JS error. This PR fixes the problem.
Note that semantically it makes more sense to give an ID to the
search box as we know exactly what search box we want.