### PR TITLE
Use key instead of keyCode

### DIFF
--- a/scribble-lib/scribble/scribble-common.js
+++ b/scribble-lib/scribble/scribble-common.js
@@ -172,7 +172,7 @@ AddOnLoad(function(){
 // Pressing "S" or "s" focuses on the "...search manuals..." text field
 AddOnLoad(function(){
   window.addEventListener("keyup", function(e) {
-    if (e.key === 's' || e.key == 'S' && e.target === document.body) {
+    if (e.key === 's' || e.key === 'S' && e.target === document.body) {
       var field = document.getElementsByClassName("searchbox")[0];
       field.focus();
     }

--- a/scribble-lib/scribble/scribble-common.js
+++ b/scribble-lib/scribble/scribble-common.js
@@ -172,7 +172,7 @@ AddOnLoad(function(){
 // Pressing "S" or "s" focuses on the "...search manuals..." text field
 AddOnLoad(function(){
   window.addEventListener("keyup", function(e) {
-    if (e.key === 's' || e.key === 'S' && e.target === document.body) {
+    if ((e.key === 's' || e.key === 'S') && e.target === document.body) {
       var field = document.getElementsByClassName("searchbox")[0];
       field.focus();
     }

--- a/scribble-lib/scribble/scribble-common.js
+++ b/scribble-lib/scribble/scribble-common.js
@@ -129,7 +129,7 @@ function NormalizePath(path) {
 
 function DoSearchKey(event, field, ver, top_path) {
   var val = field.value;
-  if (event && event.keyCode == 13) {
+  if (event && event.key === 'Enter') {
     var u = GetCookie("PLT_Root."+ver, null);
     if (u == null) u = top_path; // default: go to the top path
     u += "search/index.html?q=" + encodeURIComponent(val);
@@ -171,8 +171,8 @@ AddOnLoad(function(){
 
 // Pressing "S" or "s" focuses on the "...search manuals..." text field
 AddOnLoad(function(){
-  window.addEventListener("keyup", function(event) {
-    if (event && (event.keyCode == 83 || event.keyCode == 115) && event.target == document.body) {
+  window.addEventListener("keyup", function(e) {
+    if (e.key === 's' || e.key == 'S' && e.target === document.body) {
       var field = document.getElementsByClassName("searchbox")[0];
       field.focus();
     }


### PR DESCRIPTION
In non QWERTY keyboard, pressing S won't focus the search bar.
This PR fixes the problem.

Note that `keyCode` is not supported in IE8 already, so the fact
that `key` is not supported in IE8 too doesn't really matter:
the PR doesn't cause browser compatibility for the features to degrade.