### PR TITLE
documenting forms: disallow empty box

### DIFF
--- a/scribble-doc/scribblings/scribble/manual.scrbl
+++ b/scribble-doc/scribblings/scribble/manual.scrbl
@@ -1993,7 +1993,7 @@ Returns @racket[#t] if @racket[v] is a bibliography entry created by
 @; ------------------------------------------------------------------------
 @section{Version History}
 
-@defform[(history clause ...)
+@defform[(history clause ...+)
          #:grammar ([clause (code:line #:added version-expr)
                             (code:line #:changed version-expr content-expr)])
          #:contracts ([version-expr valid-version?]

--- a/scribble-doc/scribblings/scribble/manual.scrbl
+++ b/scribble-doc/scribblings/scribble/manual.scrbl
@@ -1381,6 +1381,29 @@ Examples:
   }]
 }
 
+@defform[(defthing* options ([id contract-expr-datum maybe-value] ...+)
+           pre-flow ...)]{
+
+Like @racket[defthing], but for multiple non-procedure bindings.
+Unlike @racket[defthing], @racket[_id-expr] is not supported.
+
+Examples:
+@codeblock[#:keep-lang-line? #f]|{
+#lang scribble/manual
+@defthing*[([moldy-sandwich sandwich?]
+            [empty-sandwich sandwich?])]{
+  Predefined sandwiches.
+}
+}|
+@doc-render-examples[
+@defthing*[#:link-target? #f
+           ([moldy-sandwich sandwich?]
+            [empty-sandwich sandwich?])]{
+  Predefined sandwiches.
+}
+]
+}
+
 
 @deftogether[(
 @defform[       (defstruct* maybe-link struct-name ([field-name contract-expr-datum] ...)

--- a/scribble-doc/scribblings/scribble/manual.scrbl
+++ b/scribble-doc/scribblings/scribble/manual.scrbl
@@ -966,7 +966,7 @@ simple, short functions.
 @defform[(defproc* options
                    ([prototype
                      result-contract-expr-datum
-                     maybe-value] ...)
+                     maybe-value] ...+)
                    pre-flow ...)]{
 
 Like @racket[defproc], but for multiple cases with the same
@@ -1447,7 +1447,7 @@ Additionally, an example using @racket[defstruct*]:
   }]
 
 
-@defform[(deftogether [def-expr ...] pre-flow ...)]{
+@defform[(deftogether [def-expr ...+] pre-flow ...)]{
 
 Combines the definitions created by the @racket[def-expr]s into a
 single definition box. Each @racket[def-expr] should produce a

--- a/scribble-lib/scribble/private/manual-form.rkt
+++ b/scribble-lib/scribble/private/manual-form.rkt
@@ -121,7 +121,7 @@
 
 (define-syntax (defform* stx)
   (syntax-parse stx
-    [(_ k:kind-kw lt:link-target?-kw d:id-kw l:literals-kw [spec ...]
+    [(_ k:kind-kw lt:link-target?-kw d:id-kw l:literals-kw [spec ...+]
         subs:subs-kw c:contracts-kw desc ...)
      (syntax/loc stx
        (defform*/subs #:kind k.kind 

--- a/scribble-lib/scribble/private/manual-history.rkt
+++ b/scribble-lib/scribble/private/manual-history.rkt
@@ -23,7 +23,7 @@
 
 (define-syntax (history stx)
   (syntax-parse stx
-    [(_ c:clause ...)
+    [(_ c:clause ...+)
      #'(make-history (list c.e ...))]))
 
 (define (make-history es)

--- a/scribble-lib/scribble/private/manual-proc.rkt
+++ b/scribble-lib/scribble/private/manual-proc.rkt
@@ -1070,7 +1070,7 @@
 
 (define-syntax (defthing* stx)
   (syntax-parse stx
-    [(_ kind:kind-kw lt:link-target?-kw ([id result value:value-kw] ...) desc ...)
+    [(_ kind:kind-kw lt:link-target?-kw ([id result value:value-kw] ...+) desc ...)
      #'(with-togetherable-racket-variables
         ()
         ()

--- a/scribble-lib/scribble/private/manual-proc.rkt
+++ b/scribble-lib/scribble/private/manual-proc.rkt
@@ -192,7 +192,7 @@
         d:id-kw
         mode:mode-kw
         within:within-kw
-        [[proto result value:value-kw] ...]
+        [[proto result value:value-kw] ...+]
         desc ...)
      (syntax/loc stx
        (with-togetherable-racket-variables

--- a/scribble-lib/scribble/private/manual-vars.rkt
+++ b/scribble-lib/scribble/private/manual-vars.rkt
@@ -9,6 +9,7 @@
          "../html-properties.rkt"
          racket/contract/base
          (for-syntax scheme/base
+                     syntax/parse
                      syntax/kerncase
                      syntax/boundmap)
          (for-label scheme/base
@@ -192,8 +193,8 @@
     (body-thunk))))
 
 (define-syntax (deftogether stx)
-  (syntax-case stx ()
-    [(_ (def ...) . body)
+  (syntax-parse stx
+    [(_ (def ...+) . body)
      (with-syntax ([((_ (lit ...) (var ...) decl) ...)
                     (map (lambda (def)
                            (let ([exp-def (local-expand 


### PR DESCRIPTION
Forms like `deftogether` and `defproc*` currently allow empty spec,
causing an empty box to be rendered. These malformed outputs are better
prevented at compile-time.

`defform*` already disallows empty spec, but the error is reported
in terms of `defform*/subs`, so this PR adjusts it to directly error
in terms of `defform*`. `defsubform*` still unfortunately errors
in terms of `defform*`, but the fix is too invasive to be worth it.

This PR is tested against all docs in the main distribution.
There's no error.