### PR TITLE
Migrate from let forms to definitions

### DIFF
--- a/scribble-doc/scribblings/scribble/class-diagrams.rkt
+++ b/scribble-doc/scribblings/scribble/class-diagrams.rkt
@@ -48,63 +48,62 @@
 
 ;; field-spec : string string -> pict
 (define (field-spec type fd #:default [default #f] [comment #f])
-  (let ([code-line
-         (hbl-append (if type 
-                         (hbl-append (type-spec type)
-                                     (normal-font " "))
-                         (blank))
-                     (field-name-font fd)
-                     (if default
-                         (hbl-append (normal-font " = ")
-                                     (normal-font default))
-                         (blank))
-                     #;
-                     (normal-font ";"))])
-    (if comment
-        (hbl-append code-line 
-                    (normal-font " ")
-                    (comment-font (format "[in ~a]" comment)))
-        code-line)))
+  (define code-line
+    (hbl-append (if type 
+                    (hbl-append (type-spec type)
+                                (normal-font " "))
+                    (blank))
+                (field-name-font fd)
+                (if default
+                    (hbl-append (normal-font " = ")
+                                (normal-font default))
+                    (blank))
+                #;
+                (normal-font ";")))
+  (if comment
+      (hbl-append code-line 
+                  (normal-font " ")
+                  (comment-font (format "[in ~a]" comment)))
+      code-line))
 
 (define (method-spec range name #:body [body #f] . args)
   (unless (even? (length args))
     (error 'method-spec "expected a list of types and argument names, but found ~a arguments"
            (length args)))
-  (let ([first-line
-         (hbl-append
-          (type-spec range)
-          (normal-font " ")
-          (var-font name)
-          (cond
-            [(null? args)
-             (normal-font "()")]
-            [else
-             (hbl-append
-              (normal-font "(")
-              (let loop ([args args])
-                (let* ([type (car args)]
-                       [param (cadr args)]
-                       [single-arg 
-                        (if param 
-                            (hbl-append (type-spec type)
-                                        (normal-font " ")
-                                        (var-font param))
-                            (type-spec type))])
-                  
-                  (cond
-                    [(null? (cddr args))
-                     (hbl-append single-arg (normal-font ")"))]
-                    [else
-                     (hbl-append single-arg
-                                 (normal-font ", ")
-                                 (loop (cddr args)))]))))])
-          (if body
-              (hbl-append (normal-font " {"))
-              (blank)))])
-    (if body
-        (vl-append first-line
-                   (hbl-append (blank 8 0) body (normal-font "}")))
-        first-line)))
+  (define first-line
+    (hbl-append
+     (type-spec range)
+     (normal-font " ")
+     (var-font name)
+     (cond
+       [(null? args)
+        (normal-font "()")]
+       [else
+        (hbl-append
+         (normal-font "(")
+         (let loop ([args args])
+           (define type (car args))
+           (define param (cadr args))
+           (define single-arg
+             (if param 
+                 (hbl-append (type-spec type)
+                             (normal-font " ")
+                             (var-font param))
+                 (type-spec type)))
+           (cond
+             [(null? (cddr args))
+              (hbl-append single-arg (normal-font ")"))]
+             [else
+              (hbl-append single-arg
+                          (normal-font ", ")
+                          (loop (cddr args)))])))])
+     (if body
+         (hbl-append (normal-font " {"))
+         (blank))))
+  (if body
+      (vl-append first-line
+                 (hbl-append (blank 8 0) body (normal-font "}")))
+      first-line))
              
 (define (type-spec str)
   (cond
@@ -126,83 +125,86 @@
 
 ;; class-box : pict (or/c #f (listof pict)) (or/c #f (listof pict)) -> pict
 (define (class-box name fields methods)
-  (let* ([mk-blank (λ () (blank 0 (+ class-box-margin class-box-margin)))])
-    (cond
-      [(and methods fields)
-       (let* ([top-spacer (mk-blank)]
-              [bottom-spacer (mk-blank)]
-              [main (vl-append name 
-                               top-spacer
-                               (if (null? fields)
-                                   (blank 0 4)
-                                   (apply vl-append fields))
-                               bottom-spacer
-                               (if (null? methods)
-                                   (blank 0 4)
-                                   (apply vl-append methods)))])
-         (add-hline
-          (add-hline (frame (inset main class-box-margin))
-                     top-spacer)
-          bottom-spacer))]
-      [fields
-       (let* ([top-spacer (mk-blank)]
-              [main (vl-append name 
-                               top-spacer
-                               (if (null? fields)
-                                   (blank)
-                                   (apply vl-append fields)))])
-         (add-hline (frame (inset main class-box-margin))
-                    top-spacer))]
-      [methods (class-box name methods fields)]
-      [else (frame (inset name class-box-margin))])))
+  (define (mk-blank)
+    (blank 0 (+ class-box-margin class-box-margin)))
+  (cond
+    [(and methods fields)
+     (define top-spacer (mk-blank))
+     (define bottom-spacer (mk-blank))
+     (define main
+       (vl-append name 
+                  top-spacer
+                  (if (null? fields)
+                      (blank 0 4)
+                      (apply vl-append fields))
+                  bottom-spacer
+                  (if (null? methods)
+                      (blank 0 4)
+                      (apply vl-append methods))))
+     (add-hline
+      (add-hline (frame (inset main class-box-margin))
+                 top-spacer)
+      bottom-spacer)]
+    [fields
+     (define top-spacer (mk-blank))
+     (define main
+       (vl-append name 
+                  top-spacer
+                  (if (null? fields)
+                      (blank)
+                      (apply vl-append fields))))
+     (add-hline (frame (inset main class-box-margin))
+                top-spacer)]
+    [methods (class-box name methods fields)]
+    [else (frame (inset name class-box-margin))]))
 
 (define (add-hline main sub)
-  (let-values ([(x y) (cc-find main sub)])
-    (pin-line main
-              sub (λ (p1 p2) (values 0 y))
-              sub (λ (p1 p2) (values (pict-width main) y)))))
+  (define-values (x y) (cc-find main sub))
+  (pin-line main
+            sub (λ (p1 p2) (values 0 y))
+            sub (λ (p1 p2) (values (pict-width main) y))))
 
 ;; hierarchy : pict (cons pict (listof pict)) (cons pict (listof pict)) -> pict
 (define (hierarchy main supers subs)
-  (let ([supers-bottoms (apply max (map (λ (x) (let-values ([(x y) (cb-find main x)]) y)) supers))]
-        [subs-tops (apply min (map (λ (x) (let-values ([(x y) (ct-find main x)]) y)) subs))]
-        [sorted-subs (sort subs (λ (x y) (< (left-edge-x main x) (left-edge-x main y))))])
-    (unless (< supers-bottoms subs-tops)
-      (error 'hierarchy "expected supers to be on top of subs, supers bottom is at ~a, and subs tops is at ~a"
-             supers-bottoms
-             subs-tops))
-    (let* ([main-line-y (max (- subs-tops 20) (/ (+ supers-bottoms subs-tops) 2))]
-           [main-line-start-x (center-x  main (car sorted-subs))]
-           [main-line-end-x (center-x main (last sorted-subs))]
-           [w/main-line
-            (pin-line main
-                      main (λ (_1 _2) (values main-line-start-x main-line-y))
-                      main (λ (_1 _2) (values main-line-end-x main-line-y))
-                      #:color hierarchy-color)]
-           [super-lines
-            (map (λ (super) 
-                   (let-values ([(x y) (cb-find main super)])
-                     (pin-over 
-                      (pin-line (ghost main)
-                                super cb-find
-                                main (λ (_1 _2) (values x main-line-y)))
-                      (- x (/ (pict-width triangle) 2))
-                      (- (/ (+ y main-line-y) 2)
-                         (/ (pict-height triangle) 2))
-                      triangle)))
-                 supers)]
-           [sub-lines
-            (map (λ (sub) 
-                   (let-values ([(x y) (ct-find main sub)])
-                     (pin-line (ghost main)
-                               sub ct-find
-                               main (λ (_1 _2) (values x main-line-y))
-                               #:color hierarchy-color)))
-                 subs)])
-      (apply cc-superimpose 
-             w/main-line
-             (append sub-lines
-                     super-lines)))))
+  (define supers-bottoms (apply max (map (λ (x) (let-values ([(x y) (cb-find main x)]) y)) supers)))
+  (define subs-tops (apply min (map (λ (x) (let-values ([(x y) (ct-find main x)]) y)) subs)))
+  (define sorted-subs (sort subs (λ (x y) (< (left-edge-x main x) (left-edge-x main y)))))
+  (unless (< supers-bottoms subs-tops)
+    (error 'hierarchy "expected supers to be on top of subs, supers bottom is at ~a, and subs tops is at ~a"
+           supers-bottoms
+           subs-tops))
+  (define main-line-y (max (- subs-tops 20) (/ (+ supers-bottoms subs-tops) 2)))
+  (define main-line-start-x (center-x  main (car sorted-subs)))
+  (define main-line-end-x (center-x main (last sorted-subs)))
+  (define w/main-line
+    (pin-line main
+              main (λ (_1 _2) (values main-line-start-x main-line-y))
+              main (λ (_1 _2) (values main-line-end-x main-line-y))
+              #:color hierarchy-color))
+  (define super-lines
+    (map (λ (super)
+           (define-values (x y) (cb-find main super))
+           (pin-over 
+            (pin-line (ghost main)
+                      super cb-find
+                      main (λ (_1 _2) (values x main-line-y)))
+            (- x (/ (pict-width triangle) 2))
+            (- (/ (+ y main-line-y) 2)
+               (/ (pict-height triangle) 2))
+            triangle))
+         supers))
+  (define sub-lines
+    (map (λ (sub)
+           (define-values (x y) (ct-find main sub))
+           (pin-line (ghost main)
+                     sub ct-find
+                     main (λ (_1 _2) (values x main-line-y))
+                     #:color hierarchy-color))
+         subs))
+  (apply cc-superimpose 
+         w/main-line
+         (append sub-lines
+                 super-lines)))
 
 (define triangle-width 12)
 (define triangle-height 12)
@@ -212,21 +214,21 @@
                       (make-object point% triangle-width triangle-height))])
     (colorize 
      (dc (λ (dc dx dy)
-           (let ([brush (send dc get-brush)])
-             (send dc set-brush (send brush get-color) 'solid)
-             (send dc draw-polygon points dx dy)
-             (send dc set-brush brush)))
+           (define brush (send dc get-brush))
+           (send dc set-brush (send brush get-color) 'solid)
+           (send dc draw-polygon points dx dy)
+           (send dc set-brush brush))
          triangle-width
          triangle-height)
      hierarchy-color)))
 
 (define (center-x main pict)
-  (let-values ([(x y) (cc-find main pict)])
-    x))
+  (define-values (x y) (cc-find main pict))
+  x)
 
 (define (left-edge-x main pict)
-  (let-values ([(x y) (lc-find main pict)])
-    x))
+  (define-values (x y) (lc-find main pict))
+  x)
 
 
 (define (add-dot-right main class field) (add-dot-left-right/offset main class field 0 rc-find))
@@ -244,9 +246,9 @@
   (add-dot-left-right/offset main class field offset lc-find))
 
 (define (add-dot-left-right/offset main class field offset finder)
-  (let-values ([(_1 y) (cc-find main field)]
-               [(x-edge _2) (finder main class)])
-    (add-dot main (+ x-edge offset) y)))
+  (define-values (_1 y) (cc-find main field))
+  (define-values (x-edge _2) (finder main class))
+  (add-dot main (+ x-edge offset) y))
 
 (define add-dot-junction
   (case-lambda
@@ -257,19 +259,19 @@
        (add-dot main x y))]))
 
 (define (add-dot-offset pict dot dx dy)
-  (let-values ([(x y) (cc-find pict dot)])
-    (add-dot pict (+ x dx) (+ y dy))))
+  (define-values (x y) (cc-find pict dot))
+  (add-dot pict (+ x dx) (+ y dy)))
 
 (define dot-δx (make-parameter 0))
 (define dot-δy (make-parameter 0))
 
 (define (add-dot pict dx dy)
-  (let ([dot (blank)])
-    (values (pin-over pict 
-                      (+ dx (dot-δx))
-                      (+ dy (dot-δy))
-                      dot)
-            dot)))
+  (define dot (blank))
+  (values (pin-over pict 
+                    (+ dx (dot-δx))
+                    (+ dy (dot-δy))
+                    dot)
+          dot))
 
 (define (connect-dots show-arrowhead? main dot1 . dots)
   (let loop ([prev-dot dot1]
@@ -427,9 +429,9 @@
     (connect-dots #t main4 dot1 dot2 dot4 dot3)))
 
 (define (find-middle main p1 find1 p2 find2)
-  (let-values ([(x1 y1) (find1 main p1)]
-               [(x2 y2) (find2 main p2)])
-    (- (/ (+ x1 x2) 2) (min x1 x2))))
+  (define-values (x1 y1) (find1 main p1))
+  (define-values (x2 y2) (find2 main p2))
+  (- (/ (+ x1 x2) 2) (min x1 x2)))
 
 (define right-top-reference
   (λ (main0 start-class start-field finish-class [count 1] #:connect-dots [connect-dots connect-dots])

--- a/scribble-doc/scribblings/scribble/struct-hierarchy.rkt
+++ b/scribble-doc/scribblings/scribble/struct-hierarchy.rkt
@@ -315,20 +315,20 @@
   (inset (panorama w/delayed-connections) 0 0 1 0))
 
 (define (double f p0 a b c d [count 1])
-  (let ([arrows1 (launder (f (ghost p0) a b c d count #:dot-delta 1))]
-        [arrows2 (launder (f (ghost p0) a b c d count #:dot-delta -1))])
-    (cc-superimpose p0
-                    arrows1
-                    arrows2)))
+  (define arrows1 (launder (f (ghost p0) a b c d count #:dot-delta 1)))
+  (define arrows2 (launder (f (ghost p0) a b c d count #:dot-delta -1)))
+  (cc-superimpose p0
+                  arrows1
+                  arrows2))
 
 (define (triple f p0 a b c d [count 1])
-  (let ([arrows (launder (f (ghost p0) a b c d count))]
-        [up-arrows (launder (f (ghost p0) a b c d count #:dot-delta 2))]
-        [down-arrows (launder (f (ghost p0) a b c d count #:dot-delta -2))])
-    (cc-superimpose p0
-                    arrows
-                    up-arrows
-                    down-arrows)))
+  (define arrows (launder (f (ghost p0) a b c d count)))
+  (define up-arrows (launder (f (ghost p0) a b c d count #:dot-delta 2)))
+  (define down-arrows (launder (f (ghost p0) a b c d count #:dot-delta -2)))
+  (cc-superimpose p0
+                  arrows
+                  up-arrows
+                  down-arrows))
 
 (define (connect-circly-dots show-arrowhead? main dot1 . dots)
   (let loop ([prev-dot dot1]
@@ -343,38 +343,38 @@
 
 ;; this is a hack -- it will only work with right-right-reference
 (define (connect-two-circly-dots pict dot1 dot2 arrowhead?)
-  (let ([base
-         (let*-values ([(sx sy) (cc-find pict dot1)]
-                       [(raw-ex ey) (cc-find pict dot2)]
-                       [(ex) (if arrowhead?
-                                 (+ raw-ex 2)
-                                 raw-ex)])
-           (cc-superimpose
-            (dc 
-             (λ (dc dx dy)
-               (let ([pen (send dc get-pen)])
-                 (send dc set-pen
-                       type-link-color ;(send pen get-color)
-                       (if (is-a? dc post-script-dc%)
-                           4
-                           2)
-                       'dot)
-                 (send dc draw-line 
-                       (+ dx sx) (+ dy sy)
-                       (+ dx ex) (+ dy ey))
-                 (send dc set-pen pen)))
-             (pict-width pict)
-             (pict-height pict))
-            pict))])
+  (define base
+    (let*-values ([(sx sy) (cc-find pict dot1)]
+                  [(raw-ex ey) (cc-find pict dot2)]
+                  [(ex) (if arrowhead?
+                            (+ raw-ex 2)
+                            raw-ex)])
+      (cc-superimpose
+       (dc 
+        (λ (dc dx dy)
+          (define pen (send dc get-pen))
+          (send dc set-pen
+                type-link-color ;(send pen get-color)
+                (if (is-a? dc post-script-dc%)
+                    4
+                    2)
+                'dot)
+          (send dc draw-line 
+                (+ dx sx) (+ dy sy)
+                (+ dx ex) (+ dy ey))
+          (send dc set-pen pen))
+        (pict-width pict)
+        (pict-height pict))
+       pict)))
   (if arrowhead?
       (pin-arrow-line field-arrowhead-size
                       base
                       dot1 (λ (ignored1 ignored2)
-                             (let-values ([(x y) (cc-find pict dot2)])
-                               (values (+ x 2) y)))
+                             (define-values (x y) (cc-find pict dot2))
+                             (values (+ x 2) y))
                       dot2 cc-find
                       #:color type-link-color)
-      base)))
+      base))
 
 (define (dotted-right-right-reference p0 a b c d [count 1])
   (right-right-reference p0 a b c d count #:connect-dots connect-circly-dots))

--- a/scribble-lib/help/search.rkt
+++ b/scribble-lib/help/search.rkt
@@ -40,8 +40,8 @@
                                            (format "q?~a" query)))
                                          null))])))]
     [else
-     (define path (build-path (find-user-doc-dir) sub))
-     (let ([path (if (file-exists? path) path (build-path (find-doc-dir) sub))])
+     (let* ([path (build-path (find-user-doc-dir) sub)]
+            [path (if (file-exists? path) path (build-path (find-doc-dir) sub))])
        (notify path)
        (cond
          [(file-exists? path)

--- a/scribble-lib/scribble/acmart.rkt
+++ b/scribble-lib/scribble/acmart.rkt
@@ -255,23 +255,23 @@
                #:date [date #f]
                #:short [short #f]
                . str)
-  (let ([content (decode-content str)])
-    (make-title-decl (prefix->string prefix)
-                     (convert-tag tag content)
-                     version
-                     (let* ([s (convert-part-style 'title style)]
-                            [s (if date
-                                   (make-style (style-name s)
-                                               (cons (make-document-date date)
-                                                     (style-properties s)))
-                                   s)]
-                            [s (if short
-                                   (make-style (style-name s)
-                                               (cons (short-title short)
-                                                     (style-properties s)))
-                                   s)])
-                       s)
-                     content)))
+  (define content (decode-content str))
+  (make-title-decl (prefix->string prefix)
+                   (convert-tag tag content)
+                   version
+                   (let* ([s (convert-part-style 'title style)]
+                          [s (if date
+                                 (make-style (style-name s)
+                                             (cons (make-document-date date)
+                                                   (style-properties s)))
+                                 s)]
+                          [s (if short
+                                 (make-style (style-name s)
+                                             (cons (short-title short)
+                                                   (style-properties s)))
+                                 s)])
+                     s)
+                   content))
 
 (define (author #:orcid [orcid #f]
                 #:affiliation [affiliation '()]

--- a/scribble-lib/scribble/acmart/lang.rkt
+++ b/scribble-lib/scribble/acmart/lang.rkt
@@ -160,21 +160,21 @@
                                                #,authorversion? #,font-size #,nonacm? #,timestamp?
                                                #,author-draft? #,acmthm? #,format?) () . body)])))]))
 
-(define ((post-process . opts) doc)  
-  (let ([options
-         (if (ormap values opts)
-             (format "[~a]" (apply string-append (add-between (filter values opts) ", ")))
-             "")])
-    (add-acmart-styles 
-     (add-defaults doc
-                   (string->bytes/utf-8
-                    (format "\\documentclass~a{acmart}\n~a"
-                            options
-                            unicode-encoding-packages))
-                   (scribble-file "acmart/style.tex")
-                   (list (scribble-file "acmart/acmart.cls"))
-                   #f
-                   #:replacements (hash "scribble-load-replace.tex" (scribble-file "acmart/acmart-load.tex"))))))
+(define ((post-process . opts) doc)
+  (define options
+    (if (ormap values opts)
+        (format "[~a]" (apply string-append (add-between (filter values opts) ", ")))
+        ""))
+  (add-acmart-styles 
+   (add-defaults doc
+                 (string->bytes/utf-8
+                  (format "\\documentclass~a{acmart}\n~a"
+                          options
+                          unicode-encoding-packages))
+                 (scribble-file "acmart/style.tex")
+                 (list (scribble-file "acmart/acmart.cls"))
+                 #f
+                 #:replacements (hash "scribble-load-replace.tex" (scribble-file "acmart/acmart-load.tex")))))
 
 (define (add-acmart-styles doc)
   (struct-copy part doc

--- a/scribble-lib/scribble/comment-reader.rkt
+++ b/scribble-lib/scribble/comment-reader.rkt
@@ -19,10 +19,10 @@
     (read-syntax/recursive src port)))
   
 (define (read-unsyntaxer port)
-  (let ([p (peeking-input-port port)])
-    (if (eq? (read p) '#:escape-id)  
-        (begin (read port) (read port))
-        'unsyntax)))
+  (define p (peeking-input-port port))
+  (if (eq? (read p) '#:escape-id)  
+      (begin (read port) (read port))
+      'unsyntax))
 
 (define (make-comment-readtable #:readtable [rt (current-readtable)])
   (make-readtable rt
@@ -32,11 +32,11 @@
                      (do-comment port (lambda () (read/recursive port #\@)))]
                     [(char port src line col pos)
                      (let ([v (do-comment port (lambda () (read-syntax/recursive src port #\@)))])
-                       (let-values ([(eline ecol epos) (port-next-location port)])
-                         (datum->syntax
-                          #f
-                          v
-                          (list src line col pos (and pos epos (- epos pos))))))])))
+                       (define-values (eline ecol epos) (port-next-location port))
+                       (datum->syntax
+                        #f
+                        v
+                        (list src line col pos (and pos epos (- epos pos)))))])))
 
 (define (do-comment port recur)
   (let loop ()
@@ -50,16 +50,16 @@
      (t
       ,@(append-strings
          (let loop ()
-           (let ([c (read-char port)])
-             (cond
-               [(or (eof-object? c)
-                    (char=? c #\newline))
-                null]
-               [(char=? c #\@)
-                (cons (recur) (loop))]
-               [else 
-                (cons (string c)
-                      (loop))]))))))))
+           (define c (read-char port))
+           (cond
+             [(or (eof-object? c)
+                  (char=? c #\newline))
+              null]
+             [(char=? c #\@)
+              (cons (recur) (loop))]
+             [else 
+              (cons (string c)
+                    (loop))])))))))
   
 (define (append-strings l)
   (let loop ([l l][s null])
@@ -76,9 +76,9 @@
                 (loop (cdr l) null)))])))
 
 (define (preserve-space s)
-  (let ([m (regexp-match-positions #rx"  +" s)])
-    (if m
-        (append (preserve-space (substring s 0 (caar m)))
-                (list `(hspace ,(- (cdar m) (caar m))))
-                (preserve-space (substring s (cdar m))))
-        (list s))))
+  (define m (regexp-match-positions #rx"  +" s))
+  (if m
+      (append (preserve-space (substring s 0 (caar m)))
+              (list `(hspace ,(- (cdar m) (caar m))))
+              (preserve-space (substring s (cdar m))))
+      (list s)))

--- a/scribble-lib/scribble/core.rkt
+++ b/scribble-lib/scribble/core.rkt
@@ -14,36 +14,37 @@
             part))
 
 (define (collect-put! ci key val)
-  (let ([ht (collect-info-ht ci)])
-    (let ([old-val (hash-ref ht key #f)])
-      (when old-val
-        (eprintf "WARNING: collected information for key multiple times: ~e; values: ~e ~e\n"
-                 key old-val val))
-      (hash-set! ht key val))))
+  (define ht (collect-info-ht ci))
+  (define old-val (hash-ref ht key #f))
+  (when old-val
+    (eprintf "WARNING: collected information for key multiple times: ~e; values: ~e ~e\n"
+             key old-val val))
+  (hash-set! ht key val))
 
 (define (resolve-get/where part ri key)
   (let ([key (tag-key key ri)])
-    (let ([v (hash-ref (if part
-                         (collected-info-info (part-collected-info part ri))
-                         (collect-info-ht (resolve-info-ci ri)))
-                       key
-                       #f)])
-      (cond
-        [v (values v #f)]
-        [part (resolve-get/where
-               (collected-info-parent (part-collected-info part ri))
-               ri key)]
-        [else
-         (define ci (resolve-info-ci ri))
-         (define (try-ext)
-           (hash-ref (collect-info-ext-ht ci) key #f))
-         (define v
-           (or (try-ext)
-               (and ((collect-info-ext-demand ci) key ci)
-                    (try-ext))))
-         (if (known-doc? v)
-             (values (known-doc-v v) (known-doc-id v))
-             (values v #t))]))))
+    (define v
+      (hash-ref (if part
+                    (collected-info-info (part-collected-info part ri))
+                    (collect-info-ht (resolve-info-ci ri)))
+                key
+                #f))
+    (cond
+      [v (values v #f)]
+      [part (resolve-get/where
+             (collected-info-parent (part-collected-info part ri))
+             ri key)]
+      [else
+       (define ci (resolve-info-ci ri))
+       (define (try-ext)
+         (hash-ref (collect-info-ext-ht ci) key #f))
+       (define v
+         (or (try-ext)
+             (and ((collect-info-ext-demand ci) key ci)
+                  (try-ext))))
+       (if (known-doc? v)
+           (values (known-doc-v v) (known-doc-id v))
+           (values v #t))])))
 
 (define (resolve-get/ext? part ri key)
   (define-values (v ext-id) (resolve-get/ext-id* part ri key #f))
@@ -53,31 +54,31 @@
   (resolve-get/ext-id* part ri key #f))
 
 (define (resolve-get/ext-id* part ri key search-key)
-  (let-values ([(v ext-id) (resolve-get/where part ri key)])
-    (when ext-id
-      (hash-set! (resolve-info-undef ri) (tag-key key ri) 
-                 (if v 'found search-key)))
-    (values v ext-id)))
+  (define-values (v ext-id) (resolve-get/where part ri key))
+  (when ext-id
+    (hash-set! (resolve-info-undef ri) (tag-key key ri) 
+               (if v 'found search-key)))
+  (values v ext-id))
 
 (define (resolve-get part ri key)
   (resolve-get* part ri key #f))
 
 (define (resolve-get* part ri key search-key)
-  (let-values ([(v ext-id) (resolve-get/ext-id* part ri key search-key)])
-    v))
+  (define-values (v ext-id) (resolve-get/ext-id* part ri key search-key))
+  v)
 
 (define (resolve-get/tentative part ri key)
-  (let-values ([(v ext-id) (resolve-get/where part ri key)])
-    v))
+  (define-values (v ext-id) (resolve-get/where part ri key))
+  v)
 
 (define (resolve-search search-key part ri key)
   (let ([s-ht (hash-ref (resolve-info-searches ri)
                         search-key
                         (lambda ()
-                          (let ([s-ht (make-hash)])
-                            (hash-set! (resolve-info-searches ri)
-                                       search-key s-ht)
-                            s-ht)))])
+                          (define s-ht (make-hash))
+                          (hash-set! (resolve-info-searches ri)
+                                     search-key s-ht)
+                          s-ht))])
     (hash-set! s-ht key #t))
   (resolve-get* part ri key search-key))
 
@@ -324,11 +325,11 @@
   prop:serializable
   (make-serialize-info
    (lambda (d)
-     (let ([ri (current-serialize-resolve-info)])
-       (unless ri
-         (error 'serialize-traverse-block
-                "current-serialize-resolve-info not set"))
-       (vector (traverse-block-block d ri))))
+     (define ri (current-serialize-resolve-info))
+     (unless ri
+       (error 'serialize-traverse-block
+              "current-serialize-resolve-info not set"))
+     (vector (traverse-block-block d ri)))
    #'deserialize-traverse-block
    #f
    (or (current-load-relative-directory) (current-directory)))
@@ -351,15 +352,15 @@
 
 (define (traverse-block-block b i)
   (cond
-   [(collect-info? i)
-    (let ([p (hash-ref (collect-info-fp i) b #f)])
-      (if (block? p)
-          p
-          (error 'traverse-block-block
-                 "no block computed for traverse-block: ~e"
-                 b)))]
-   [(resolve-info? i)
-    (traverse-block-block b (resolve-info-ci i))]))
+    [(collect-info? i)
+     (define p (hash-ref (collect-info-fp i) b #f))
+     (if (block? p)
+         p
+         (error 'traverse-block-block
+                "no block computed for traverse-block: ~e"
+                b))]
+    [(resolve-info? i)
+     (traverse-block-block b (resolve-info-ci i))]))
 
 (provide/contract
  [traverse-block-block (traverse-block?
@@ -374,11 +375,11 @@
   prop:serializable
   (make-serialize-info
    (lambda (d)
-     (let ([ri (current-serialize-resolve-info)])
-       (unless ri
-         (error 'serialize-traverse-block
-                "current-serialize-resolve-info not set"))
-       (vector (traverse-element-content d ri))))
+     (define ri (current-serialize-resolve-info))
+     (unless ri
+       (error 'serialize-traverse-block
+              "current-serialize-resolve-info not set"))
+     (vector (traverse-element-content d ri)))
    #'deserialize-traverse-element
    #f
    (or (current-load-relative-directory) (current-directory)))
@@ -400,15 +401,15 @@
 
 (define (traverse-element-content e i)
   (cond
-   [(collect-info? i)
-    (let ([c (hash-ref (collect-info-fp i) e #f)])
-      (if (content? c)
-          c
-          (error 'traverse-block-block
-                 "no block computed for traverse-block: ~e"
-                 e)))]
-   [(resolve-info? i)
-    (traverse-element-content e (resolve-info-ci i))]))
+    [(collect-info? i)
+     (define c (hash-ref (collect-info-fp i) e #f))
+     (if (content? c)
+         c
+         (error 'traverse-block-block
+                "no block computed for traverse-block: ~e"
+                e))]
+    [(resolve-info? i)
+     (traverse-element-content e (resolve-info-ci i))]))
 
 (provide element-traverse-procedure/c)
 (provide/contract
@@ -424,16 +425,16 @@
   prop:serializable
   (make-serialize-info
    (lambda (d)
-     (let ([ri (current-serialize-resolve-info)])
-       (unless ri
-         (error 'serialize-delayed-element
-                "current-serialize-resolve-info not set"))
-       (with-handlers ([exn:fail:contract?
-                        (lambda (exn)
-                          (error 'serialize-delayed-element
-                                 "serialization failed (wrong resolve info? delayed element never rendered?); ~a"
-                                 (exn-message exn)))])
-         (vector (delayed-element-content d ri)))))
+     (define ri (current-serialize-resolve-info))
+     (unless ri
+       (error 'serialize-delayed-element
+              "current-serialize-resolve-info not set"))
+     (with-handlers ([exn:fail:contract?
+                      (lambda (exn)
+                        (error 'serialize-delayed-element
+                               "serialization failed (wrong resolve info? delayed element never rendered?); ~a"
+                               (exn-message exn)))])
+       (vector (delayed-element-content d ri))))
    #'deserialize-delayed-element
    #f
    (or (current-load-relative-directory) (current-directory)))
@@ -468,17 +469,17 @@
   prop:serializable
   (make-serialize-info
    (lambda (d)
-     (let ([ri (current-serialize-resolve-info)])
-       (unless ri
-         (error 'serialize-part-relative-element
-                "current-serialize-resolve-info not set"))
-       (with-handlers ([exn:fail:contract?
-                        (lambda (exn)
-                          (error 'serialize-part-relative-element
-                                 "serialization failed (wrong resolve info? part-relative element never rendered?); ~a"
-                                 (exn-message exn)))])
-         (vector
-          (part-relative-element-content d ri)))))
+     (define ri (current-serialize-resolve-info))
+     (unless ri
+       (error 'serialize-part-relative-element
+              "current-serialize-resolve-info not set"))
+     (with-handlers ([exn:fail:contract?
+                      (lambda (exn)
+                        (error 'serialize-part-relative-element
+                               "serialization failed (wrong resolve info? part-relative element never rendered?); ~a"
+                               (exn-message exn)))])
+       (vector
+        (part-relative-element-content d ri))))
    #'deserialize-part-relative-element
    #f
    (or (current-load-relative-directory) (current-directory)))
@@ -512,17 +513,17 @@
   prop:serializable 
   (make-serialize-info
    (lambda (d)
-     (let ([ri (current-serialize-resolve-info)])
-       (unless ri
-         (error 'serialize-delayed-index-desc
-                "current-serialize-resolve-info not set"))
-       (with-handlers ([exn:fail:contract?
-                        (lambda (exn)
-                          (error 'serialize-index-desc
-                                 "serialization failed (wrong resolve info?); ~a"
-                                 (exn-message exn)))])
-         (vector
-          (delayed-element-content d ri)))))
+     (define ri (current-serialize-resolve-info))
+     (unless ri
+       (error 'serialize-delayed-index-desc
+              "current-serialize-resolve-info not set"))
+     (with-handlers ([exn:fail:contract?
+                      (lambda (exn)
+                        (error 'serialize-index-desc
+                               "serialization failed (wrong resolve info?); ~a"
+                               (exn-message exn)))])
+       (vector
+        (delayed-element-content d ri))))
    #'deserialize-delayed-index-desc
    #f
    (or (current-load-relative-directory) (current-directory)))
@@ -594,15 +595,15 @@
   prop:serializable
   (make-serialize-info
    (lambda (g)
-     (let ([ri (current-serialize-resolve-info)])
-       (unless ri
+     (define ri (current-serialize-resolve-info))
+     (unless ri
+       (error 'serialize-generated-tag
+              "current-serialize-resolve-info not set"))
+     (define t (hash-ref (collect-info-tags (resolve-info-ci ri)) g #f))
+     (if t
+         (vector t)
          (error 'serialize-generated-tag
-                "current-serialize-resolve-info not set"))
-       (let ([t (hash-ref (collect-info-tags (resolve-info-ci ri)) g #f)])
-         (if t
-           (vector t)
-           (error 'serialize-generated-tag
-                  "serialization failed (wrong resolve info?)")))))
+                "serialization failed (wrong resolve info?)")))
    #'deserialize-generated-tag
    #f
    (or (current-load-relative-directory) (current-directory)))
@@ -620,17 +621,19 @@
          add-current-tag-prefix)
 
 (define (generate-tag tg ci)
-  (if (generated-tag? (cadr tg))
-      (let ([t (cadr tg)])
-        (list (car tg)
-              (let ([tags (collect-info-tags ci)])
-                (or (hash-ref tags t #f)
-                    (let ([key (list* 'gentag
-                                      (hash-count tags)
-                                      (collect-info-gen-prefix ci))])
-                      (hash-set! tags t key)
-                      key)))))
-      tg))
+  (cond
+    [(generated-tag? (cadr tg))
+     (define t (cadr tg))
+     (list (car tg)
+           (let ([tags (collect-info-tags ci)])
+             (or (hash-ref tags t #f)
+                 (let ([key (list* 'gentag
+                                   (hash-count tags)
+                                   (collect-info-gen-prefix ci))])
+                   (hash-set! tags t key)
+                   key))))]
+    [else
+     tg]))
 
 (define (tag-key tg ri)
   (if (generated-tag? (cadr tg))
@@ -640,10 +643,10 @@
 
 (define current-tag-prefixes (make-parameter null))
 (define (add-current-tag-prefix t)
-  (let ([l (current-tag-prefixes)])
-    (if (null? l)
-        t
-        (cons (car t) (append l (cdr t))))))
+  (define l (current-tag-prefixes))
+  (if (null? l)
+      t
+      (cons (car t) (append l (cdr t)))))
 
 ;; ----------------------------------------
 
@@ -684,12 +687,12 @@
                            (strip-aux
                             (if (pair? dest) (cadr dest) (vector-ref dest 1)))
                            renderer sec ri)
-            (display "???" op)))]
+            (display "???" op))]
        [(element? c) (content->port op (element-content c) renderer sec ri)]
        [(multiarg-element? c) (content->port op (multiarg-element-contents c) renderer sec ri)]
        [(list? c) (for-each (lambda (e)
                               (content->port op e renderer sec ri))
-                             c)]
+                            c)]
        [(delayed-element? c)
         (content->port op (delayed-element-content c ri) renderer sec ri)]
        [(part-relative-element? c)
@@ -721,10 +724,12 @@
 
 
 (define (aux-element? e)
-  (and (element? e)
-       (let ([s (element-style e)])
-         (and (style? s)
-              (memq 'aux (style-properties s))))))
+  (cond
+    [(not (element? e)) #f]
+    [else
+     (define s (element-style e))
+     (and (style? s)
+          (memq 'aux (style-properties s)))]))
 
 (define (strip-aux content)
   (cond
@@ -775,14 +780,14 @@
     [(eq? p 'cont) 0]))
 
 (define (table-width p)
-  (let ([blocks (table-blockss p)])
-    (if (null? blocks)
+  (define blocks (table-blockss p))
+  (if (null? blocks)
       0
       (let loop ([blocks blocks])
         (if (null? (car blocks))
-          0
-          (+ (apply max 0 (map block-width (map car blocks)))
-             (loop (map cdr blocks))))))))
+            0
+            (+ (apply max 0 (map block-width (map car blocks)))
+               (loop (map cdr blocks)))))))
 
 (define (itemization-width p)
   (apply max 0 (map flow-width (itemization-blockss p))))

--- a/scribble-lib/scribble/html-render.rkt
+++ b/scribble-lib/scribble/html-render.rkt
@@ -74,23 +74,23 @@
                 p))]
          [file-getter
           (lambda (default-file make-inline make-ref)
-            (define c #f)
-            (lambda (file path depth)
-              (cond [(bytes? file)
-                     (make-inline (bytes->string/utf-8 file))]
-                    [(url? file)
-                     (make-ref (url->string* file))]
-                    [(not (eq? 'inline path))
-                     (make-ref (adjust-rel
-                                depth
-                                (or path (let-values ([(base name dir?)
-                                                       (split-path file)])
-                                           (path->string name)))))]
-                    [(or (not file) (equal? file default-file))
-                     (unless c
-                       (set! c (make-inline (read-file default-file))))
-                     c]
-                    [else (make-inline (read-file file))])))])
+            (let ([c #f])
+              (lambda (file path depth)
+                (cond [(bytes? file)
+                       (make-inline (bytes->string/utf-8 file))]
+                      [(url? file)
+                       (make-ref (url->string* file))]
+                      [(not (eq? 'inline path))
+                       (make-ref (adjust-rel
+                                  depth
+                                  (or path (let-values ([(base name dir?)
+                                                         (split-path file)])
+                                             (path->string name)))))]
+                      [(or (not file) (equal? file default-file))
+                       (unless c
+                         (set! c (make-inline (read-file default-file))))
+                       c]
+                      [else (make-inline (read-file file))]))))])
     (values (file-getter scribble-css inlined-style  ref-style)
             (file-getter scribble-js  inlined-script ref-script))))
 
@@ -142,8 +142,8 @@
       (string-append*
        "#"
        (map (lambda (v)
-              (define s (number->string v 16))
-              (if (< v 16) (string-append "0" s) s))
+              (let ([s (number->string v 16)])
+                (if (< v 16) (string-append "0" s) s)))
             c))))
 
 (define (merge-styles s cls l)
@@ -167,35 +167,34 @@
    [else (cons (car l) (merge-styles s cls (cdr l)))]))
 
 (define (style->attribs style [extras null])
-  (define a
-    (merge-styles
-     #f
-     #f
-     (apply
-      append
-      extras
-      (map (lambda (v)
-             (cond
-               [(attributes? v)
-                (map (lambda (v) (list (car v) (cdr v))) (attributes-assoc v))]
-               [(color-property? v)
-                `((style ,(format "color: ~a" (color->string (color-property-color v)))))]
-               [(background-color-property? v)
-                `((style ,(format "background-color: ~a" (color->string (background-color-property-color v)))))]
-               [(hover-property? v)
-                `((title ,(hover-property-text v)))]
-               [else null]))
-           (style-properties style)))))
-  (define name (style-name style))
-  (if (string? name)
-      (if (assq 'class a)
-          (for/list ([i (in-list a)])
-            (if (eq? (car i) 'class)
-                (list 'class (string-append name " " (cadr i)))
-                i))
-          (cons `[class ,name]
-                a))
-      a))
+  (let ([a (merge-styles
+            #f
+            #f
+            (apply
+             append
+             extras
+             (map (lambda (v)
+                    (cond
+                     [(attributes? v)
+                      (map (lambda (v) (list (car v) (cdr v))) (attributes-assoc v))]
+                     [(color-property? v)
+                      `((style ,(format "color: ~a" (color->string (color-property-color v)))))]
+                     [(background-color-property? v)
+                      `((style ,(format "background-color: ~a" (color->string (background-color-property-color v)))))]
+                     [(hover-property? v)
+                      `((title ,(hover-property-text v)))]
+                     [else null]))
+                  (style-properties style))))])
+    (let ([name (style-name style)])
+      (if (string? name)
+          (if (assq 'class a)
+              (for/list ([i (in-list a)])
+                (if (eq? (car i) 'class)
+                    (list 'class (string-append name " " (cadr i)))
+                    i))
+              (cons `[class ,name]
+                    a))
+          a))))
 
 ;; combine a 'class attribute from both `cl' and `al'
 ;;  if `cl' starts with one
@@ -222,17 +221,17 @@
          (string->symbol (alt-tag-name s)))))
 
 (define (make-search-box top-path) ; appears on every page
-  (define emptylabel "...search manuals...")
-  `(form ([class "searchform"])
-         (input
-          ([class "searchbox"]
-           [id "searchbox"]
-           [type "text"]
-           [tabindex "1"]
-           [placeholder ,emptylabel]
-           [title "Enter a search string to search the manuals"]
-           [onkeypress ,(format "return DoSearchKey(event, this, ~s, ~s);"
-                                (version) top-path)]))))
+  (let ([emptylabel "...search manuals..."])
+    `(form ([class "searchform"])
+       (input
+        ([class "searchbox"]
+         [id "searchbox"]
+         [type "text"]
+         [tabindex "1"]
+         [placeholder ,emptylabel]
+         [title "Enter a search string to search the manuals"]
+         [onkeypress ,(format "return DoSearchKey(event, this, ~s, ~s);"
+                              (version) top-path)])))))
 (define search-box (make-search-box "../"))
 (define top-search-box (make-search-box ""))
 
@@ -346,8 +345,8 @@
                 fns))
 
     (define/public (part-whole-page? p ri)
-      (define dest (resolve-get p ri (car (part-tags/nonempty p))))
-      (and dest (dest-page? dest)))
+      (let ([dest (resolve-get p ri (car (part-tags/nonempty p)))])
+        (and dest (dest-page? dest))))
 
     (define/public (current-part-whole-page? d)
       (eq? d (current-top-part)))
@@ -380,27 +379,25 @@
                               v))))))
 
     (define/override (collect-target-element i ci)
-      (define key (generate-tag (target-element-tag i) ci))
-      (collect-put! ci key
-                    (vector (let ([tag (target-element-tag i)])
-                              (if (and (pair? tag) (eq? 'part (car tag)))
-                                  (element-content i)
-                                  #f))
-                            (if (redirect-target-element? i)
-                                (make-literal-anchor
-                                 (redirect-target-element-alt-anchor i))
-                                (add-current-tag-prefix key))
-                            #f ; for consistency with 'part info
-                            (path->relative
-                             (let ([p (current-output-file)])
-                               (cond
-                                 [(redirect-target-element? i)
-                                  (define-values (base name dir?) (split-path p))
-                                  (build-path base
-                                              (redirect-target-element-alt-path i))]
-                                 [else
-                                  p])))
-                            (page-target-element? i))))
+      (let ([key (generate-tag (target-element-tag i) ci)])
+        (collect-put! ci key
+                      (vector (let ([tag (target-element-tag i)])
+                                (if (and (pair? tag) (eq? 'part (car tag)))
+                                    (element-content i)
+                                    #f))
+                              (if (redirect-target-element? i)
+                                  (make-literal-anchor
+                                   (redirect-target-element-alt-anchor i))
+                                  (add-current-tag-prefix key))
+                              #f ; for consistency with 'part info
+                              (path->relative
+                               (let ([p (current-output-file)])
+                                 (if (redirect-target-element? i)
+                                     (let-values ([(base name dir?) (split-path p)])
+                                       (build-path base
+                                                   (redirect-target-element-alt-path i)))
+                                     p)))
+                              (page-target-element? i)))))
 
     (define (dest-path dest)
       (vector-ref dest 3))
@@ -454,23 +451,23 @@
 
     (define/public (tag->path+anchor ri tag)
       ;; Called externally; not used internally
-      (define-values (dest ext?) (resolve-get/ext? #f ri tag))
-      (cond [(not dest) (values #f #f)]
-            [(and ext? external-root-url
-                  (try-relative-to-external-root dest))
-             => (lambda (p)
-                  (values (car p) (cdr p)))]
-            [(and ext? external-tag-path)
-             (values (string->url external-tag-path) (format "~a" (serialize tag)))]
-            [else (values (relative->path (dest-path dest))
-                          (and (not (dest-page? dest))
-                               (anchor-name (dest-anchor dest))))]))
+      (let-values ([(dest ext?) (resolve-get/ext? #f ri tag)])
+        (cond [(not dest) (values #f #f)]
+              [(and ext? external-root-url
+                    (try-relative-to-external-root dest))
+               => (lambda (p)
+                    (values (car p) (cdr p)))]
+              [(and ext? external-tag-path)
+               (values (string->url external-tag-path) (format "~a" (serialize tag)))]
+              [else (values (relative->path (dest-path dest))
+                            (and (not (dest-page? dest))
+                                 (anchor-name (dest-anchor dest))))])))
 
     (define/public (tag->url-string ri tag #:absolute? [abs? #f])
       ;; Called externally; not used internally
-      (define-values (dest ext?) (resolve-get/ext? #f ri tag))
-      (cond [(not dest) ""]
-            [else (dest->url dest abs?)]))
+      (let-values ([(dest ext?) (resolve-get/ext? #f ri tag)])
+        (cond [(not dest) ""]
+              [else (dest->url dest abs?)])))
 
     (define/public (tag->query-string tag)
       (define (simple? s)
@@ -534,16 +531,16 @@
                    ;; directory doesn't match `ext-id`:
                    (let loop ([path (relative->path (dest-path dest))]
                               [empty-ok? #f])
-                     (define-values (base name dir?) (split-path path))
-                     (cond
-                       [(and empty-ok?
-                             dir? 
-                             (equal? (format "~a" name) (format "~a" ext-id)))
-                        #f]
-                       [(path? base)
-                        (define r (loop base #t))
-                        (if r (build-path r name) name)]
-                       [else name]))
+                     (let-values ([(base name dir?) (split-path path)])
+                       (cond
+                        [(and empty-ok?
+                              dir? 
+                              (equal? (format "~a" name) (format "~a" ext-id)))
+                         #f]
+                        [(path? base)
+                         (define r (loop base #t))
+                         (if r (build-path r name) name)]
+                        [else name])))
                    (if (dest-page? dest) "" "#")
                    (if (dest-page? dest)
                        ""
@@ -748,53 +745,54 @@
                 ,@(get-onthispage-label)
                 (table ([class "tocsublist"] [cellspacing "0"])
                   ,@(map (lambda (p)
-                                (let ([p (vector-ref p 0)])
-                                  (define prefixes (vector-ref p 1))
-                                  (define from-d (vector-ref p 2))
-                                  (define (add-tag-prefixes t prefixes)
+                           (let ([p (vector-ref p 0)]
+                                 [prefixes (vector-ref p 1)]
+                                 [from-d (vector-ref p 2)]
+                                 [add-tag-prefixes
+                                  (lambda (t prefixes)
                                     (if (null? prefixes)
                                         t
-                                        (cons (car t) (append prefixes (cdr t)))))
-                                  `(tr
-                                    (td
-                                     ,@(if (part? p)
-                                           `((span ([class "tocsublinknumber"])
-                                                   ,@(format-number
-                                                      (collected-info-number
-                                                       (part-collected-info p ri))
-                                                      '((tt nbsp)))))
-                                           '(""))
-                                     ,@(if (toc-element? p)
-                                           (render-content (toc-element-toc-content p)
-                                                           from-d ri)
-                                           (parameterize ([current-no-links #t]
-                                                          [extra-breaking? #t])
-                                             `((a ([href
-                                                    ,(format
-                                                      "#~a"
-                                                      (uri-unreserved-encode
-                                                       (anchor-name
-                                                        (add-tag-prefixes
-                                                         (tag-key (if (part? p)
-                                                                      (car (part-tags/nonempty p))
-                                                                      (target-element-tag p))
-                                                                  ri)
-                                                         prefixes))))]
-                                                   [class
-                                                       ,(cond
-                                                          [(part? p) "tocsubseclink"]
-                                                          [any-parts? "tocsubnonseclink"]
-                                                          [else "tocsublink"])]
-                                                   [data-pltdoc "x"])
-                                                  ,@(render-content
-                                                     (if (part? p)
-                                                         (strip-aux
-                                                          (or (part-title-content p)
-                                                              "???"))
-                                                         (if (toc-target2-element? p)
-                                                             (toc-target2-element-toc-content p)
-                                                             (element-content p)))
-                                                     from-d ri)))))))))
+                                        (cons (car t) (append prefixes (cdr t)))))])
+                             `(tr
+                               (td
+                                ,@(if (part? p)
+                                      `((span ([class "tocsublinknumber"])
+                                              ,@(format-number
+                                                 (collected-info-number
+                                                  (part-collected-info p ri))
+                                                 '((tt nbsp)))))
+                                      '(""))
+                                ,@(if (toc-element? p)
+                                      (render-content (toc-element-toc-content p)
+                                                      from-d ri)
+                                      (parameterize ([current-no-links #t]
+                                                     [extra-breaking? #t])
+                                        `((a ([href
+                                               ,(format
+                                                 "#~a"
+                                                 (uri-unreserved-encode
+                                                  (anchor-name
+                                                   (add-tag-prefixes
+                                                    (tag-key (if (part? p)
+                                                                 (car (part-tags/nonempty p))
+                                                                 (target-element-tag p))
+                                                             ri)
+                                                    prefixes))))]
+                                              [class
+                                                  ,(cond
+                                                    [(part? p) "tocsubseclink"]
+                                                    [any-parts? "tocsubnonseclink"]
+                                                    [else "tocsublink"])]
+                                              [data-pltdoc "x"])
+                                             ,@(render-content
+                                                (if (part? p)
+                                                    (strip-aux
+                                                     (or (part-title-content p)
+                                                         "???"))
+                                                    (if (toc-target2-element? p)
+                                                        (toc-target2-element-toc-content p)
+                                                        (element-content p)))
+                                                from-d ri)))))))))
                          ps)))))))
 
     (define/private (extract-inherited d ri pred extract)
@@ -822,22 +820,18 @@
                                (let ([p (part-parent d ri)])
                                  (and p (loop p)))))]
                [prefix-file (or prefix-file 
-                                (cond
-                                  [(not defaults) #f]
-                                  [else
-                                   (define v (html-defaults-prefix-path defaults))
-                                   (if (bytes? v)
-                                       v
-                                       (collects-relative->path v))])
+                                (and defaults
+                                     (let ([v (html-defaults-prefix-path defaults)])
+                                       (if (bytes? v)
+                                           v
+                                           (collects-relative->path v))))
                                 scribble-prefix-html)]
                [style-file (or style-file 
-                               (cond
-                                 [(not defaults) #f]
-                                 [else
-                                  (define v (html-defaults-style-path defaults))
-                                  (if (bytes? v)
-                                      v
-                                      (collects-relative->path v))])
+                               (and defaults
+                                    (let ([v (html-defaults-style-path defaults)])
+                                      (if (bytes? v)
+                                          v
+                                          (collects-relative->path v))))
                                scribble-style-css)]
                [script-file (or script-file scribble-js)]
                [title (cond [(part-title-content d)
@@ -878,13 +872,11 @@
                                            (lookup-path scribble-css alt-paths) 
                                            dir-depth)
                    ,@(map (lambda (style-file)
-                            (cond
-                              [(or (bytes? style-file) (url? style-file))
-                               (scribble-css-contents style-file #f dir-depth)]
-                              [else
-                               (define p (lookup-path style-file alt-paths))
-                               (unless p (install-file style-file))
-                               (scribble-css-contents style-file p dir-depth)]))
+                            (if (or (bytes? style-file) (url? style-file))
+                                (scribble-css-contents style-file #f dir-depth)
+                                (let ([p (lookup-path style-file alt-paths)])
+                                  (unless p (install-file style-file))
+                                  (scribble-css-contents style-file p dir-depth))))
                           (append (extract css-addition? css-addition-path)
                                   (list style-file)
                                   (extract css-style-addition? css-style-addition-path)
@@ -893,13 +885,11 @@
                                           (lookup-path script-file alt-paths)
                                           dir-depth)
                    ,@(map (lambda (script-file)
-                            (cond
-                              [(or (bytes? script-file) (url? script-file))
-                               (scribble-js-contents script-file #f dir-depth)]
-                              [else
-                               (define p (lookup-path script-file alt-paths))
-                               (unless p (install-file script-file))
-                               (scribble-js-contents script-file p dir-depth)]))
+                            (if (or (bytes? script-file) (url? script-file))
+                                (scribble-js-contents script-file #f dir-depth)
+                                (let ([p (lookup-path script-file alt-paths)])
+                                  (unless p (install-file script-file))
+                                  (scribble-js-contents script-file p dir-depth))))
                           (append
                            (extract js-addition? js-addition-path)
                            (extract js-style-addition? js-style-addition-path)
@@ -929,17 +919,17 @@
            (part-parent d ri)))
 
     (define/private (find-siblings d ri)
-      (define parent (collected-info-parent (part-collected-info d ri)))
-      (let loop ([l (cond
-                      [parent (part-parts parent)]
-                      [(or (null? (part-parts d))
-                           (not (part-whole-page? (car (part-parts d)) ri)))
-                       (list d)]
-                      [else (list d (car (part-parts d)))])]
-                 [prev #f])
-        (if (eq? (car l) d)
+      (let ([parent (collected-info-parent (part-collected-info d ri))])
+        (let loop ([l (cond
+                        [parent (part-parts parent)]
+                        [(or (null? (part-parts d))
+                             (not (part-whole-page? (car (part-parts d)) ri)))
+                         (list d)]
+                        [else (list d (car (part-parts d)))])]
+                   [prev #f])
+          (if (eq? (car l) d)
             (values prev (and (pair? (cdr l)) (cadr l)))
-            (loop (cdr l) (car l)))))
+            (loop (cdr l) (car l))))))
 
     (define top-content      "top")
     (define contents-content "contents")
@@ -975,18 +965,14 @@
               [else next0]))
       (define index
         (let loop ([d d])
-          (define p (part-parent d ri))
-          (cond
-            [p
-             (loop p)]
-            [else
-             (define subs (part-parts d))
-             (cond
-               [(not (pair? subs)) #f]
-               [else
-                (define d (last subs))
-                (and (eq? (style-name (part-style d)) 'index)
-                     d)])])))
+          (let ([p (part-parent d ri)])
+            (if p
+              (loop p)
+              (let ([subs (part-parts d)])
+                (and (pair? subs)
+                     (let ([d (last subs)])
+                       (and (eq? (style-name (part-style d)) 'index)
+                            d))))))))
       (define (render . content)
         (render-content (filter values content) d ri))
       (define (titled-url label x #:title-from [tfrom #f] . more)
@@ -1089,19 +1075,19 @@
       (render-one-part d ri fn null))
 
     (define/public (render-version d ri)
-      (define v (current-version))
-      (if (equal? v "")
-          ;; don't show empty version:
-          null
-          ;; show version:
-          `((div ([class "versionbox"])
-                 ,@(render-content
-                    (list (make-element (if (include-navigation?)
-                                            "version"
-                                            "versionNoNav")
-                                        v))
-                    d
-                    ri)))))
+      (let ([v (current-version)])
+        (if (equal? v "")
+            ;; don't show empty version:
+            null
+            ;; show version:
+            `((div ([class "versionbox"])
+                   ,@(render-content
+                      (list (make-element (if (include-navigation?)
+                                              "version"
+                                              "versionNoNav")
+                                          v))
+                      d
+                      ri))))))
 
     (define/public (extract-render-convertible-as d)
       (for/or ([v (in-list (style-properties (part-style d)))])
@@ -1198,29 +1184,29 @@
       (render-flow* p part ri starting-item? #t))
 
     (define/private (do-render-paragraph p part ri flatten-unstyled? show-pre?)
-      (define contents (super render-paragraph p part ri))
-      (define style (paragraph-style p))
-      (define attrs (style->attribs style))
-      (if (and (not show-pre?)
-               (or (eq? (style-name style) 'author)
-                   (eq? (style-name style) 'pretitle)))
-          null
-          (if (and flatten-unstyled?
-                   (not (style-name style))
-                   (null? attrs))
-              contents
-              `((,(or (style->tag style)
-                      (if (memq 'div (style-properties style)) 
-                          'div 
-                          'p))
-                 [,@(combine-class
-                     (case (style-name style)
-                       [(author) '([class "author"])]
-                       [(pretitle) '([class "SPretitle"])]
-                       [(wraps) null]
-                       [else null])
-                     attrs)]
-                 ,@contents)))))
+      (let* ([contents (super render-paragraph p part ri)]
+             [style (paragraph-style p)]
+             [attrs (style->attribs style)])
+        (if (and (not show-pre?)
+                 (or (eq? (style-name style) 'author)
+                     (eq? (style-name style) 'pretitle)))
+            null
+            (if (and flatten-unstyled?
+                     (not (style-name style))
+                     (null? attrs))
+                contents
+                `((,(or (style->tag style)
+                        (if (memq 'div (style-properties style)) 
+                            'div 
+                            'p))
+                   [,@(combine-class
+                       (case (style-name style)
+                         [(author) '([class "author"])]
+                         [(pretitle) '([class "SPretitle"])]
+                         [(wraps) null]
+                         [else null])
+                       attrs)]
+                   ,@contents))))))
 
     (define/override (render-paragraph p part ri)
       (do-render-paragraph p part ri #f #f))
@@ -1238,10 +1224,10 @@
        [else #f]))
 
     (define/private (content-attribs e [extras null])
-      (define s (content-style e))
-      (if (style? s)
-          (element-style->attribs (style-name s) s extras)
-          (element-style->attribs s #f extras)))
+      (let ([s (content-style e)])
+          (if (style? s)
+              (element-style->attribs (style-name s) s extras)
+              (element-style->attribs s #f extras))))
 
     (define (element-style-property-matching e pred)
       (and (or (element? e) (multiarg-element? e))
@@ -1260,81 +1246,80 @@
               (render-as-convertible e (current-render-convertible-requests)))
          => values]
         [(image-element? e)
-         (define src (collects-relative->path (image-element-path e)))
-         (define suffixes (image-element-suffixes e))
-         (define scale (image-element-scale e))
-         (define (to-scaled-num s)
-           (number->string
-            (inexact->exact
-             (floor (* scale (if (number? s)
-                                 s
-                                 (integer-bytes->integer s #f #t)))))))
-         (let ([src (select-suffix src suffixes '(".png" ".gif" ".svg"))])
-           (define svg? (regexp-match? #rx#"[.]svg$" (if (path? src) (path->bytes src) src)))
-           (define sz
-             (cond
-               [svg?
-                (define (to-scaled-num-from-str s)
-                  (define parts
-                    (regexp-match
-                     #rx"^([+-]?[0-9]*\\.?([0-9]+)?)(em|ex|px|in|cm|mm|pt|pc|%|)$"
-                     s))
-                  (cond
-                    [parts
-                     (string-append
-                      (number->string
-                       (* scale
-                          (string->number (list-ref parts 1))))
-                      (list-ref parts 3))]
-                    [else s]))
-                (call-with-input-file*
-                    src
-                  (lambda (in)
-                    (with-handlers ([exn:fail? (lambda (exn) 
-                                                 (log-warning
-                                                  (format "warning: error while reading SVG file for size: ~a"
-                                                          (if (exn? exn)
-                                                              (exn-message exn)
-                                                              (format "~e" exn))))
-                                                 null)])
-                      (let* ([d (xml:read-xml in)]
-                             [attribs (xml:element-attributes 
-                                       (xml:document-element d))]
-                             [check-name (lambda (n)
-                                           (lambda (a)
-                                             (and (eq? n (xml:attribute-name a))
-                                                  (xml:attribute-value a))))]
-                             [w (ormap (check-name 'width) attribs)]
-                             [h (ormap (check-name 'height) attribs)])
-                        (if (and w h)
-                            `([width ,(to-scaled-num-from-str w)]
-                              [height ,(to-scaled-num-from-str h)])
-                            null)))))]
-               [else
-                ;; Try to extract file size:
-                (call-with-input-file*
-                    src
-                  (lambda (in)
-                    (cond
-                      [(regexp-try-match #px#"^\211PNG.{12}" in)
-                       `([width ,(to-scaled-num (read-bytes 4 in))]
-                         [height ,(to-scaled-num (read-bytes 4 in))])]
-                      [(regexp-try-match #px#"^(?=GIF8)" in)
-                       (define-values (w h rows) (gif->rgba-rows in))
-                       `([width ,(to-scaled-num w)]
-                         [height ,(to-scaled-num h)])]
-                      [else
-                       null])))]))
-           (define srcref
-             (let ([p (install-file src)])
-               (if (path? p)
-                   (url->string* (path->url (path->complete-path p)))
-                   p)))
-           `((img
-              ([src ,srcref]
-               [alt ,(content->string (element-content e))]
-               ,@sz
-               ,@(attribs)))))]
+         (let* ([src (collects-relative->path (image-element-path e))]
+                [suffixes (image-element-suffixes e)]
+                [scale (image-element-scale e)]
+                [to-scaled-num
+                 (lambda (s)
+                   (number->string
+                    (inexact->exact
+                     (floor (* scale (if (number? s)
+                                         s
+                                         (integer-bytes->integer s #f #t)))))))]
+                [src (select-suffix src suffixes '(".png" ".gif" ".svg"))]
+                [svg? (regexp-match? #rx#"[.]svg$" (if (path? src) (path->bytes src) src))]
+                [sz (cond
+                     [svg?
+                      (define (to-scaled-num-from-str s)
+                        (define parts
+                          (regexp-match
+                           #rx"^([+-]?[0-9]*\\.?([0-9]+)?)(em|ex|px|in|cm|mm|pt|pc|%|)$"
+                           s))
+                        (cond
+                          [parts
+                           (string-append
+                            (number->string
+                             (* scale
+                                (string->number (list-ref parts 1))))
+                            (list-ref parts 3))]
+                          [else s]))
+                      (call-with-input-file*
+                       src
+                       (lambda (in)
+                         (with-handlers ([exn:fail? (lambda (exn) 
+                                                      (log-warning
+                                                       (format "warning: error while reading SVG file for size: ~a"
+                                                               (if (exn? exn)
+                                                                   (exn-message exn)
+                                                                   (format "~e" exn))))
+                                                      null)])
+                           (let* ([d (xml:read-xml in)]
+                                  [attribs (xml:element-attributes 
+                                            (xml:document-element d))]
+                                  [check-name (lambda (n)
+                                                (lambda (a)
+                                                  (and (eq? n (xml:attribute-name a))
+                                                       (xml:attribute-value a))))]
+                                  [w (ormap (check-name 'width) attribs)]
+                                  [h (ormap (check-name 'height) attribs)])
+                             (if (and w h)
+                                 `([width ,(to-scaled-num-from-str w)]
+                                   [height ,(to-scaled-num-from-str h)])
+                                 null)))))]
+                     [else
+                      ;; Try to extract file size:
+                      (call-with-input-file*
+                       src
+                       (lambda (in)
+                         (cond
+                          [(regexp-try-match #px#"^\211PNG.{12}" in)
+                           `([width ,(to-scaled-num (read-bytes 4 in))]
+                             [height ,(to-scaled-num (read-bytes 4 in))])]
+                          [(regexp-try-match #px#"^(?=GIF8)" in)
+                           (define-values (w h rows) (gif->rgba-rows in))
+                           `([width ,(to-scaled-num w)]
+                             [height ,(to-scaled-num h)])]
+                          [else
+                           null])))])])
+           (let ([srcref (let ([p (install-file src)])
+                           (if (path? p)
+                               (url->string* (path->url (path->complete-path p)))
+                               p))])
+             `((img
+                ([src ,srcref]
+                 [alt ,(content->string (element-content e))]
+                 ,@sz
+                 ,@(attribs))))))]
         [(element-style-property-matching e script-property?)
          => 
          (lambda (v)
@@ -1385,72 +1370,72 @@
                                "section "))]
                        [else '()])
                    (a ([href
-                        ,(cond
-                           [(and ext-id external-root-url dest
-                                 (let* ([ref-path (relative->path (dest-path dest))]
-                                        [rel (if (relative-path? ref-path)
-                                                 #f
-                                                 (find-relative-path
-                                                  (find-doc-dir)
-                                                  ref-path))])
-                                   (and rel
-                                        (relative-path? rel)
-                                        (not (memq 'up (explode-path rel)))
-                                        rel)))
-                            => (lambda (rel)
-                                 (url->string*
-                                  (struct-copy
-                                   url
-                                   (combine-url/relative
-                                    (string->url external-root-url)
-                                    (string-join (map (lambda (s)
-                                                        (case s
-                                                          [(up) ".."]
-                                                          [(same) "."]
-                                                          [else (path-element->string s)]))
-                                                      (explode-path rel))
-                                                 "/"))
-                                   [fragment
-                                    (and (not (dest-page? dest))
-                                         (anchor-name (dest-anchor dest)))])))]
-                           [(or indirect-link?
-                                (and ext-id external-tag-path))
-                            ;; Redirected to search:
-                            (url->string*
-                             (let ([u (string->url (or external-tag-path
-                                                       (get-doc-search-url)))])
+                      ,(cond
+                        [(and ext-id external-root-url dest
+                              (let* ([ref-path (relative->path (dest-path dest))]
+                                     [rel (if (relative-path? ref-path)
+                                              #f
+                                              (find-relative-path
+                                               (find-doc-dir)
+                                               ref-path))])
+                                (and rel
+                                     (relative-path? rel)
+                                     (not (memq 'up (explode-path rel)))
+                                     rel)))
+                         => (lambda (rel)
+                              (url->string*
                                (struct-copy
                                 url
-                                u
-                                [query
-                                 (if (string? ext-id)
-                                     (list* (cons 'doc ext-id)
-                                            (cons 'rel (or (dest->url-in-doc dest ext-id) "???"))
-                                            (url-query u))
-                                     (cons (cons 'tag (tag->query-string (link-element-tag e)))
-                                           (url-query u)))])))]
-                           [else
-                            ;; Normal link:
-                            (dest->url dest)])]
-                       ,@(attribs (if (or indirect-link?
-                                          (and ext-id external-tag-path))
-                                      '([class "Sq"])
-                                      null))
-                       [data-pltdoc "x"])
-                      ,@(if (empty-content? (element-content e))
-                            (cond
-                              [number-link? (format-number (dest-number dest) '(""))]
-                              [else
-                               (render-content (strip-aux (dest-title dest)) part ri)])
-                            (render-content (element-content e) part ri))))
-                 (begin
-                   (when #f
-                     (eprintf "Undefined link: ~s\n"
-                              (tag-key (link-element-tag e) ri)))
-                   `((font ([class "badlink"])
-                           ,@(if (empty-content? (element-content e))
-                                 `(,(format "~s" (tag-key (link-element-tag e) ri)))
-                                 (render-plain-content e part ri))))))))]
+                                (combine-url/relative
+                                 (string->url external-root-url)
+                                 (string-join (map (lambda (s)
+                                                     (case s
+                                                       [(up) ".."]
+                                                       [(same) "."]
+                                                       [else (path-element->string s)]))
+                                                   (explode-path rel))
+                                              "/"))
+                                [fragment
+                                 (and (not (dest-page? dest))
+                                      (anchor-name (dest-anchor dest)))])))]
+                        [(or indirect-link?
+                             (and ext-id external-tag-path))
+                         ;; Redirected to search:
+                         (url->string*
+                          (let ([u (string->url (or external-tag-path
+                                                    (get-doc-search-url)))])
+                            (struct-copy
+                             url
+                             u
+                             [query
+                              (if (string? ext-id)
+                                  (list* (cons 'doc ext-id)
+                                         (cons 'rel (or (dest->url-in-doc dest ext-id) "???"))
+                                         (url-query u))
+                                  (cons (cons 'tag (tag->query-string (link-element-tag e)))
+                                        (url-query u)))])))]
+                        [else
+                         ;; Normal link:
+                         (dest->url dest)])]
+                     ,@(attribs (if (or indirect-link?
+                                        (and ext-id external-tag-path))
+                                    '([class "Sq"])
+                                    null))
+                     [data-pltdoc "x"])
+                    ,@(if (empty-content? (element-content e))
+                          (cond
+                            [number-link? (format-number (dest-number dest) '(""))]
+                            [else
+                             (render-content (strip-aux (dest-title dest)) part ri)])
+                          (render-content (element-content e) part ri))))
+               (begin
+                 (when #f
+                   (eprintf "Undefined link: ~s\n"
+                            (tag-key (link-element-tag e) ri)))
+                 `((font ([class "badlink"])
+                     ,@(if (empty-content? (element-content e))
+                         `(,(format "~s" (tag-key (link-element-tag e) ri)))
+                         (render-plain-content e part ri))))))))]
         [else 
          (render-plain-content e part ri)]))
     
@@ -1469,40 +1454,38 @@
              [else #f])
            => 
            (lambda (cvt)
-             (define bstr (if (list? cvt) (first cvt) cvt))
-             (define w
-               (if (list? cvt)
-                   (list-ref cvt 1)
-                   (integer-bytes->integer (subbytes bstr 16 20) #f #t)))
-             (define h
-               (if (list? cvt)
-                   (list-ref cvt 2)
-                   (integer-bytes->integer (subbytes bstr 20 24) #f #t)))
-             (define (scale v)
-               (if (and (not (list? cvt))
-                        (equal? request 'png@2x-bytes))
-                   (/ v 2.0)
-                   v))
-             (list
-              (add-padding
-               cvt
-               `(img ([src ,(install-file "pict.png" bstr)]
-                      [alt "image"]
-                      [width ,(number->decimal-string (scale w))]
-                      [height ,(number->decimal-string (scale h))])))))]
+             (let* ([bstr (if (list? cvt) (first cvt) cvt)]
+                    [w (if (list? cvt)
+                           (list-ref cvt 1)
+                           (integer-bytes->integer (subbytes bstr 16 20) #f #t))]
+                    [h (if (list? cvt)
+                           (list-ref cvt 2)
+                           (integer-bytes->integer (subbytes bstr 20 24) #f #t))]
+                    [scale (lambda (v)
+                             (if (and (not (list? cvt))
+                                      (equal? request 'png@2x-bytes))
+                                 (/ v 2.0)
+                                 v))])
+               (list
+                (add-padding
+                 cvt
+                 `(img ([src ,(install-file "pict.png" bstr)]
+                        [alt "image"]
+                        [width ,(number->decimal-string (scale w))]
+                        [height ,(number->decimal-string (scale h))]))))))]
           [(case request
              [(svg-bytes)
               (or (convert e 'svg-bytes+bounds8)
                   (convert e 'svg-bytes))]
              [else #f])
            => (lambda (cvt)
-                (define bstr (if (list? cvt) (first cvt) cvt))
-                (list
-                 (add-padding
-                  cvt
-                  `(img
-                    ([src ,(install-file "pict.svg" bstr)]
-                     [type "image/svg+xml"])))))]
+                (let* ([bstr (if (list? cvt) (first cvt) cvt)])
+                  (list
+                   (add-padding
+                    cvt
+                    `(img
+                      ([src ,(install-file "pict.svg" bstr)]
+                       [type "image/svg+xml"]))))))]
           [(and (equal? request 'gif-bytes) (convert e 'gif-bytes))
            =>
            (lambda (gif-bytes)
@@ -1548,39 +1531,34 @@
 
     (define/private (render-plain-content e part ri)
       (define (attribs) (content-attribs e))
-      (define properties
-        (let ([s (content-style e)])
-          (if (style? s)
-              (style-properties s)
-              null)))
-      (define name
-        (let ([s (content-style e)])
-          (if (style? s)
-              (style-name s)
-              s)))
-      (define alt-tag
-        (let ([s (content-style e)])
-          (and (style? s)
-               (style->tag s))))
-      (define resources
-        (for/list ([p (in-list properties)]
-                   #:when (install-resource? p))
-          (install-resource-path p)))
-      (define link-resource
-        (for/or ([p (in-list properties)]
-                 #:when (link-resource? p))
-          (link-resource-path p)))
-      (define link?
-        (and (or (ormap target-url? properties)
-                 link-resource)
-             (not (current-no-links))))
-      (define anchor? (ormap url-anchor? properties))
-      (let ([attribs
-             (append
-              (if (null? properties)
-                  null
-                  (append-map (lambda (v)
-                                (cond
+      (let* ([properties (let ([s (content-style e)])
+                           (if (style? s)
+                               (style-properties s)
+                               null))]
+             [name (let ([s (content-style e)])
+                     (if (style? s)
+                         (style-name s)
+                         s))]
+             [alt-tag
+              (let ([s (content-style e)])
+                (and (style? s)
+                     (style->tag s)))]
+             [resources (for/list ([p (in-list properties)]
+                                   #:when (install-resource? p))
+                          (install-resource-path p))]
+             [link-resource (for/or ([p (in-list properties)]
+                                     #:when (link-resource? p))
+                              (link-resource-path p))]
+             [link? (and (or (ormap target-url? properties)
+                             link-resource)
+                         (not (current-no-links)))]
+             [anchor? (ormap url-anchor? properties)]
+             [attribs
+              (append
+               (if (null? properties)
+                   null
+                   (append-map (lambda (v)
+                                 (cond
                                   [(target-url? v)
                                    (if (current-no-links)
                                        null
@@ -1589,50 +1567,50 @@
                                                       (from-root addr (get-dest-directory))
                                                       addr))]))]
                                   [else null]))
-                              properties))
-              (attribs))])
-        (define newline? (eq? name 'newline))
-        (define (check-render)
-          (when (render-element? e)
-            ((render-element-render e) this part ri)))
+                               properties))
+               (attribs))]
+             [newline? (eq? name 'newline)]
+             [check-render
+              (lambda ()
+                (when (render-element? e)
+                  ((render-element-render e) this part ri)))])
         (for ([r (in-list resources)])
           (install-file r))
-        (define content
-          (cond
-            [link?
-             (parameterize ([current-no-links #t])
-               (super render-content e part ri))]
-            [newline? (check-render) null]
-            [(eq? 'hspace name)
-             (check-render)
-             (define str (content->string e))
-             (map (lambda (c) 'nbsp) (string->list str))]
-            [else
-             (super render-content e part ri)]))
-        (if (and (null? attribs) 
-                 (not link?)
-                 (not anchor?)
-                 (not newline?)
-                 (not alt-tag))
-            content
-            `(,@(if anchor?
-                    (append-map (lambda (v)
-                                  (if (url-anchor? v)
-                                      `((a ([name ,(url-anchor-name v)])))
-                                      null))
-                                properties)
-                    null)
-              (,(cond
-                  [alt-tag alt-tag]
-                  [link? 'a]
-                  [newline? 'br]
-                  [else 'span]) 
-               ,(append
-                 (if link-resource
-                     `([href ,(install-file link-resource)])
-                     null)
-                 attribs)
-               ,@content)))))
+        (let-values ([(content) (cond
+                                 [link?
+                                  (parameterize ([current-no-links #t])
+                                    (super render-content e part ri))]
+                                 [newline? (check-render) null]
+                                 [(eq? 'hspace name)
+                                  (check-render)
+                                  (let ([str (content->string e)])
+                                    (map (lambda (c) 'nbsp) (string->list str)))]
+                                 [else
+                                  (super render-content e part ri)])])
+          (if (and (null? attribs) 
+                   (not link?)
+                   (not anchor?)
+                   (not newline?)
+                   (not alt-tag))
+              content
+              `(,@(if anchor?
+                      (append-map (lambda (v)
+                                    (if (url-anchor? v)
+                                        `((a ([name ,(url-anchor-name v)])))
+                                        null))
+                                  properties)
+                      null)
+                (,(cond
+                   [alt-tag alt-tag]
+                   [link? 'a]
+                   [newline? 'br]
+                   [else 'span]) 
+                 ,(append
+                   (if link-resource
+                       `([href ,(install-file link-resource)])
+                       null)
+                   attribs)
+                 ,@content))))))
 
     (define/private (element-style->attribs name style [extras null])
       (combine-class
@@ -1669,41 +1647,40 @@
                        [column-styles column-styles]
                        [first? #t])
               (cond
-                [(null? ds) null]
-                [(eq? (car ds) 'cont)
-                 (loop (cdr ds) (cdr column-styles) first?)]
-                [else
-                 (define d (car ds))
-                 (define column-style (car column-styles))
-                 (cons
-                  `(td (,@(cond
+               [(null? ds) null]
+               [(eq? (car ds) 'cont)
+                (loop (cdr ds) (cdr column-styles) first?)]
+               [else
+                (let ([d (car ds)] [column-style (car column-styles)])
+                  (cons
+                   `(td (,@(cond
                             [(not column-style) null]
                             [(memq 'right (style-properties column-style)) '([align "right"])]
                             [(memq 'left (style-properties column-style)) '([align "left"])]
                             [(memq 'center (style-properties column-style)) '([align "center"])]
                             [else null])
-                        ,@(cond
+                         ,@(cond
                             [(not column-style) null]
                             [(memq 'top (style-properties column-style)) '([valign "top"])]
                             [(memq 'baseline (style-properties column-style)) '([valign "baseline"])]
                             [(memq 'vcenter (style-properties column-style)) '([valign "center"])]
                             [(memq 'bottom (style-properties column-style)) '([valign "bottom"])]
                             [else null])
-                        ,@(if (and column-style
-                                   (string? (style-name column-style)))
-                              `([class ,(style-name column-style)])
-                              null)
-                        ,@(if (and column-style
-                                   (pair? (style-properties column-style)))
-                              (style->attribs (make-style
-                                               #f
-                                               (filter (lambda (a)
-                                                         (or (attributes? a)
-                                                             (color-property? a)
-                                                             (background-color-property? a)))
-                                                       (style-properties column-style)))
-                                              (let ([ps (style-properties column-style)])
-                                                (cond
+                         ,@(if (and column-style
+                                    (string? (style-name column-style)))
+                               `([class ,(style-name column-style)])
+                               null)
+                         ,@(if (and column-style
+                                    (pair? (style-properties column-style)))
+                               (style->attribs (make-style
+                                                #f
+                                                (filter (lambda (a)
+                                                          (or (attributes? a)
+                                                              (color-property? a)
+                                                              (background-color-property? a)))
+                                                        (style-properties column-style)))
+                                               (let ([ps (style-properties column-style)])
+                                                 (cond
                                                   [(memq 'border ps)
                                                    `([style "border: 1px solid black;"])]
                                                   [else
@@ -1716,22 +1693,22 @@
                                                     (check 'bottom-border 'bottom)
                                                     (check 'left-border 'left)
                                                     (check 'right-border 'right))])))
-                              null)
-                        ,@(if (and (pair? (cdr ds))
-                                   (eq? 'cont (cadr ds)))
-                              `([colspan
-                                 ,(number->string
-                                   (let loop ([n 2] [ds (cddr ds)])
-                                     (cond [(null? ds) n]
-                                           [(eq? 'cont (car ds))
-                                            (loop (+ n 1) (cdr ds))]
-                                           [else n])))])
-                              null))
-                       ,@(if (and (paragraph? d)
-                                  (memq 'omitable (style-properties (paragraph-style d))))
-                             (render-content (paragraph-content d) part ri)
-                             (render-block d part ri #f)))
-                  (loop (cdr ds) (cdr column-styles) #f))]))))
+                               null)
+                         ,@(if (and (pair? (cdr ds))
+                                    (eq? 'cont (cadr ds)))
+                               `([colspan
+                                  ,(number->string
+                                    (let loop ([n 2] [ds (cddr ds)])
+                                      (cond [(null? ds) n]
+                                            [(eq? 'cont (car ds))
+                                             (loop (+ n 1) (cdr ds))]
+                                            [else n])))])
+                               null))
+                        ,@(if (and (paragraph? d)
+                                   (memq 'omitable (style-properties (paragraph-style d))))
+                              (render-content (paragraph-content d) part ri)
+                              (render-block d part ri #f)))
+                   (loop (cdr ds) (cdr column-styles) #f)))]))))
       (define cell-styless (extract-table-cell-styles t))
       `((table ([cellspacing "0"]
                 [cellpadding "0"]
@@ -1747,15 +1724,13 @@
                                         null)
                                     (if (for/or ([cell-styles (in-list cell-styless)])
                                           (for/or ([cell-style (in-list cell-styles)])
-                                            (cond
-                                              [(not cell-style) #f]
-                                              [else
-                                               (define ps (style-properties cell-style))
-                                               (or (memq 'border ps)
-                                                   (memq 'left-border ps)
-                                                   (memq 'right-border ps)
-                                                   (memq 'bottom-border ps)
-                                                   (memq 'top-border ps))])))
+                                            (and cell-style
+                                                 (let ([ps (style-properties cell-style)])
+                                                   (or (memq 'border ps)
+                                                       (memq 'left-border ps)
+                                                       (memq 'right-border ps)
+                                                       (memq 'bottom-border ps)
+                                                       (memq 'top-border ps))))))
                                         `([style "border-collapse: collapse;"])
                                         '())))))
           ,@(let ([columns (ormap (lambda (p)
@@ -1796,35 +1771,33 @@
                   (super render-nested-flow t part ri starting-item?)))))
 
     (define/override (render-compound-paragraph t part ri starting-item?)
-      (define style (compound-paragraph-style t))
-      `((,(or (style->tag style) 'p)
-         ,(style->attribs style)
-         ,@(super render-compound-paragraph t part ri starting-item?))))
+      (let ([style (compound-paragraph-style t)])
+        `((,(or (style->tag style) 'p)
+           ,(style->attribs style)
+           ,@(super render-compound-paragraph t part ri starting-item?)))))
 
     (define/override (render-itemization t part ri)
-      (define style-str
-        (and (string? (style-name (itemization-style t)))
-             (style-name (itemization-style t))))
-      `((,(if (eq? 'ordered (style-name (itemization-style t)))
-              'ol
-              'ul)
-         (,@(style->attribs (itemization-style t))
-          ,@(if (eq? 'compact (style-name (itemization-style t)))
-                `([class "compact"])
-                '()))
-         ,@(map (lambda (flow) `(li ,(if style-str
-                                         `([class ,(string-append style-str "Item")])
-                                         `())
-                                    ,@(render-flow flow part ri #t)))
-                (itemization-blockss t)))))
+      (let ([style-str (and (string? (style-name (itemization-style t)))
+                            (style-name (itemization-style t)))])
+        `((,(if (eq? 'ordered (style-name (itemization-style t)))
+                'ol
+                'ul)
+           (,@(style->attribs (itemization-style t))
+            ,@(if (eq? 'compact (style-name (itemization-style t)))
+                  `([class "compact"])
+                  '()))
+           ,@(map (lambda (flow) `(li ,(if style-str
+                                           `([class ,(string-append style-str "Item")])
+                                           `())
+                                      ,@(render-flow flow part ri #t)))
+                  (itemization-blockss t))))))
 
     (define/override (render-other i part ri)
       (cond
         [(string? i)
-         (define m
-           (and (extra-breaking?)
-                (regexp-match-positions #rx"[-:/+_](?=.)|[a-z](?=[A-Z])" i)))
-         (if m
+         (let ([m (and (extra-breaking?)
+                       (regexp-match-positions #rx"[-:/+_](?=.)|[a-z](?=[A-Z])" i))])
+           (if m
              (list* (substring i 0 (cdar m))
                     ;; Most browsers wrap after a hyphen. The one that
                     ;; doesn't, Firefox, pays attention to wbr.  Some
@@ -1834,7 +1807,7 @@
                         '(wbr)
                         '(span ([class "mywbr"]) " " nbsp))
                     (render-other (substring i (cdar m)) part ri))
-             (ascii-ize i))]
+             (ascii-ize i)))]
         [(symbol? i)
          (case i
            [(mdash) '(#x2014 (wbr))] ;; <wbr> encourages breaking after rather than before
@@ -1873,16 +1846,14 @@
          (list (format "~s" i))]))
     
     (define/private (ascii-ize s)
-      (cond
-        [(= (string-utf-8-length s) (string-length s))
-         (list s)]
-        [else
-         (define m (regexp-match-positions #rx"[^\u01-\u7E]" s))
-         (if m
-             (append (ascii-ize (substring s 0 (caar m)))
-                     (list (char->integer (string-ref s (caar m))))
-                     (ascii-ize (substring s (cdar m))))
-             (list s))]))
+      (if (= (string-utf-8-length s) (string-length s))
+          (list s)
+          (let ([m (regexp-match-positions #rx"[^\u01-\u7E]" s)])
+            (if m
+                (append (ascii-ize (substring s 0 (caar m)))
+                        (list (char->integer (string-ref s (caar m))))
+                        (ascii-ize (substring s (cdar m))))
+                (list s)))))
 
     ;; ----------------------------------------
 
@@ -1909,33 +1880,29 @@
     (define/override (get-suffix) #"")
 
     (define/override (get-dest-directory [create? #f])
-      (or (cond
-            [(not (current-subdirectory)) #f]
-            [else
-             (define d
-               (build-path (or (super get-dest-directory)
-                               (current-directory))
-                           (current-subdirectory)))
-             (when (and create? (not (directory-exists? d)))
-               (make-directory* d))
-             d])
+      (or (and (current-subdirectory)
+               (let ([d (build-path (or (super get-dest-directory)
+                                        (current-directory))
+                                    (current-subdirectory))])
+                 (when (and create? (not (directory-exists? d)))
+                   (make-directory* d))
+                 d))
           (super get-dest-directory create?)))
 
     (define/private (append-part-prefixes d ci ri)
-      (define parents
-        (drop-right
-         (if ci
-             (cons d (collect-info-parents ci))
-             (let loop ([d d])
-               (if d
-                   (cons d
-                         (loop (collected-info-parent (part-collected-info d ri))))
-                   null)))
-         1))
-      (apply
-       string-append
-       (for/list ([p (in-list parents)])
-         (or (part-tag-prefix p) ""))))
+      (let ([parents (drop-right
+                      (if ci
+                          (cons d (collect-info-parents ci))
+                          (let loop ([d d])
+                            (if d
+                                (cons d
+                                      (loop (collected-info-parent (part-collected-info d ri))))
+                                null)))
+                      1)])
+        (apply
+         string-append
+         (for/list ([p (in-list parents)])
+           (or (part-tag-prefix p) "")))))
 
     (define/override (part-nesting-depth d ri)
       (min (part-depth d ri) (sub1 directory-depth)))
@@ -1947,26 +1914,24 @@
           (add1 (part-depth p ri))))
 
     (define/override (derive-filename d ci ri depth)
-      (define base
-        (regexp-replace*
-         "[^-a-zA-Z0-9_=]"
-         (string-append
-          (append-part-prefixes d ci ri)
-          (let ([s (cadr (car (part-tags/nonempty d)))])
-            (cond [(string? s) s]
-                  [(part-title-content d)
-                   (content->string (part-title-content d))]
-                  [else
-                   ;; last-ditch effort to make up a unique name:
-                   (format "???~a" (eq-hash-code d))])))
-         "_"))
-      (define fn
-        (if (depth . < . directory-depth)
-            (path->string (build-path base "index.html"))
-            (format "~a.html" base)))
-      (when ((string-length fn) . >= . 48)
-        (error "file name too long (need a tag):" fn))
-      fn)
+      (let ([base (regexp-replace*
+                   "[^-a-zA-Z0-9_=]"
+                   (string-append
+                    (append-part-prefixes d ci ri)
+                    (let ([s (cadr (car (part-tags/nonempty d)))])
+                      (cond [(string? s) s]
+                            [(part-title-content d)
+                             (content->string (part-title-content d))]
+                            [else
+                             ;; last-ditch effort to make up a unique name:
+                             (format "???~a" (eq-hash-code d))])))
+                   "_")])
+        (let ([fn (if (depth . < . directory-depth)
+                      (path->string (build-path base "index.html"))
+                      (format "~a.html" base))])
+          (when ((string-length fn) . >= . 48)
+            (error "file name too long (need a tag):" fn))
+          fn)))
 
     (define/override (include-navigation?) #t)
 
@@ -1993,31 +1958,28 @@
                   fns)))
 
     (define/private (check-duplicate-filename orig-s)
-      (define s (string-downcase (path->string orig-s)))
-      (when (hash-ref (current-part-files) s #f)
-        (error 'htmls-render "multiple parts have the same filename (modulo case): ~e"
-               orig-s))
-      (hash-set! (current-part-files) s #t))
+      (let ([s (string-downcase (path->string orig-s))])
+        (when (hash-ref (current-part-files) s #f)
+          (error 'htmls-render "multiple parts have the same filename (modulo case): ~e"
+                 orig-s))
+        (hash-set! (current-part-files) s #t)))
 
     (define/override (collect-part d parent ci number sub-init-number sub-init-numberers)
-      (define prev-sub (collecting-sub))
-      (parameterize ([collecting-sub (if (part-style? d 'toc)
-                                         1 
-                                         (add1 prev-sub))]
-                     [collecting-whole-page (prev-sub . <= . 1)])
-        (cond
-          [(and (current-part-whole-page? d)
-                (not (eq? d (current-top-part))))
-           (define filename (derive-filename d ci #f (length number)))
-           (define full-filename
-             (build-path (path-only (current-output-file))
-                         filename))
-           (make-directory* (path-only full-filename))
-           (check-duplicate-filename full-filename)
-           (parameterize ([current-output-file full-filename])
-             (super collect-part d parent ci number sub-init-number sub-init-numberers))]
-          [else
-           (super collect-part d parent ci number sub-init-number sub-init-numberers)])))
+      (let ([prev-sub (collecting-sub)])
+        (parameterize ([collecting-sub (if (part-style? d 'toc)
+                                           1 
+                                           (add1 prev-sub))]
+                       [collecting-whole-page (prev-sub . <= . 1)])
+          (if (and (current-part-whole-page? d)
+                   (not (eq? d (current-top-part))))
+              (let* ([filename (derive-filename d ci #f (length number))]
+                     [full-filename (build-path (path-only (current-output-file))
+                                                filename)])
+                (make-directory* (path-only full-filename))
+                (check-duplicate-filename full-filename)
+                (parameterize ([current-output-file full-filename])
+                  (super collect-part d parent ci number sub-init-number sub-init-numberers)))
+              (super collect-part d parent ci number sub-init-number sub-init-numberers)))))
 
     (define/override (render-top ds fns ri)
       (map (lambda (d fn)

--- a/scribble-lib/scribble/markdown-render.rkt
+++ b/scribble-lib/scribble/markdown-render.rkt
@@ -54,29 +54,29 @@
                                 markdown-part-tag)))))
 
     (define/override (render-part d ht)
-      (let ([number (collected-info-number (part-collected-info d ht))])
-        (unless (part-style? d 'hidden)
-          (printf (string-append (make-string (add1 (number-depth number)) #\#) " "))
-          (let ([s (format-number number '() #t)])
-            (unless (null? s)
-              (printf "~a~a" 
-                      (car s)
-                      (if (part-title-content d)
-                          " "
-                          "")))
-            (when (part-title-content d)
-              (render-content (part-title-content d) d ht))
-            (when (or (pair? number) (part-title-content d))
-              (newline)
-              (newline))))
-        (render-flow (part-blocks d) d ht #f)
-        (let loop ([pos 1]
-                   [secs (part-parts d)]
-                   [need-newline? (pair? (part-blocks d))])
-          (unless (null? secs)
-            (when need-newline? (newline))
-            (render-part (car secs) ht)
-            (loop (add1 pos) (cdr secs) #t)))))
+      (define number (collected-info-number (part-collected-info d ht)))
+      (unless (part-style? d 'hidden)
+        (printf (string-append (make-string (add1 (number-depth number)) #\#) " "))
+        (let ([s (format-number number '() #t)])
+          (unless (null? s)
+            (printf "~a~a" 
+                    (car s)
+                    (if (part-title-content d)
+                        " "
+                        "")))
+          (when (part-title-content d)
+            (render-content (part-title-content d) d ht))
+          (when (or (pair? number) (part-title-content d))
+            (newline)
+            (newline))))
+      (render-flow (part-blocks d) d ht #f)
+      (let loop ([pos 1]
+                 [secs (part-parts d)]
+                 [need-newline? (pair? (part-blocks d))])
+        (unless (null? secs)
+          (when need-newline? (newline))
+          (render-part (car secs) ht)
+          (loop (add1 pos) (cdr secs) #t))))
 
     (define/override (render-flow f part ht starting-item?)
       (if (null? f)
@@ -109,17 +109,19 @@
         [else
           (define strs (map (lambda (flows)
                               (map (lambda (d)
-                                     (if (eq? d 'cont)
-                                         d
-                                         (let ([o (open-output-string)])
-                                           (parameterize ([current-indent 0]
-                                                          [current-output-port o])
-                                             (render-block d part ht #f))
-                                           (regexp-split
-                                            #rx"\n"
-                                            (regexp-replace #rx"\n$"
-                                                            (get-output-string o)
-                                                            "")))))
+                                     (cond
+                                       [(eq? d 'cont)
+                                        d]
+                                       [else
+                                        (define o (open-output-string))
+                                        (parameterize ([current-indent 0]
+                                                       [current-output-port o])
+                                          (render-block d part ht #f))
+                                        (regexp-split
+                                         #rx"\n"
+                                         (regexp-replace #rx"\n$"
+                                                         (get-output-string o)
+                                                         ""))]))
                                    flows))
                             flowss))
           (define widths (map (lambda (col)
@@ -131,38 +133,39 @@
           (define x-length (lambda (col) (if (eq? col 'cont) 0 (length col))))
           (for/fold ([indent? #f]) ([row (in-list strs)])
             (let ([h (apply max 0 (map x-length row))])
-              (let ([row* (for/list ([i (in-range h)])
-                            (for/list ([col (in-list row)])
-                              (if (i . < . (x-length col))
-                                  (list-ref col i)
-                                  "")))])
-                (for/fold ([indent? indent?]) ([sub-row (in-list row*)])
-                  (when indent? (indent))
-                  (for/fold ([space? #f])
-                      ([col (in-list sub-row)]
-                       [w (in-list widths)])
-                    (let ([col (if (eq? col 'cont) "" col)])
-                      (display (regexp-replace* #rx"\uA0" col " "))
-                      (display (make-string (max 0 (- w (string-length col))) #\space)))
-                    #t)
-                  (newline)
-                  #t)))
+              (define row*
+                (for/list ([i (in-range h)])
+                  (for/list ([col (in-list row)])
+                    (if (i . < . (x-length col))
+                        (list-ref col i)
+                        ""))))
+              (for/fold ([indent? indent?]) ([sub-row (in-list row*)])
+                (when indent? (indent))
+                (for/fold ([space? #f])
+                          ([col (in-list sub-row)]
+                           [w (in-list widths)])
+                  (let ([col (if (eq? col 'cont) "" col)])
+                    (display (regexp-replace* #rx"\uA0" col " "))
+                    (display (make-string (max 0 (- w (string-length col))) #\space)))
+                  #t)
+                (newline)
+                #t))
             #t)])
       null)
 
     (define/override (render-itemization i part ht)
-      (let ([flows (itemization-blockss i)])
-        (if (null? flows)
-            null
-            (append*
-             (begin (printf "* ")
-                    (parameterize ([current-indent (make-indent 2)])
-                      (render-flow (car flows) part ht #t)))
-             (for/list ([d (in-list (cdr flows))])
-               (indented-newline)
-               (printf "* ")
-               (parameterize ([current-indent (make-indent 2)])
-                 (render-flow d part ht #f)))))))
+      (define flows (itemization-blockss i))
+      (if (null? flows)
+          null
+          (append*
+           (begin (printf "* ")
+                  (parameterize ([current-indent (make-indent 2)])
+                    (render-flow (car flows) part ht #t)))
+           (for/list ([d (in-list (cdr flows))])
+             (indented-newline)
+             (printf "* ")
+             (parameterize ([current-indent (make-indent 2)])
+               (render-flow d part ht #f))))))
 
     (define/override (render-paragraph p part ri)
       (define (write-note)
@@ -220,26 +223,30 @@
       (and (element? i) (eq? (element-style i) 'emph)))
 
     (define (code? i)
-      (and (element? i)
-           (let ([s (element-style i)])
-             (or (eq? 'tt s)
-                 (and (style? s)
-                      (style-name s)
-                      (regexp-match? #rx"^Rkt[A-Z]" (style-name s)))))))
+      (cond
+        [(not (element? i)) #f]
+        [else
+         (define s (element-style i))
+         (or (eq? 'tt s)
+             (and (style? s)
+                  (style-name s)
+                  (regexp-match? #rx"^Rkt[A-Z]" (style-name s))))]))
 
     (define (link? i)
-      (let ([s (content-style i)])
-        (and (style? s) (findf target-url? (style-properties s)))))
+      (define s (content-style i))
+      (and (style? s) (findf target-url? (style-properties s))))
 
     (define (link-from i)
       (target-url-addr (findf target-url? (style-properties (content-style i)))))
 
     (define (preserve-spaces? i)
-      (and (element? i)
-           (let ([s (element-style i)])
-             (or (eq? 'hspace s)
-                 (and (style? s)
-                      (eq? 'hspace (style-name s)))))))
+      (cond
+        [(not (element? i)) #f]
+        [else
+         (define s (element-style i))
+         (or (eq? 'hspace s)
+             (and (style? s)
+                  (eq? 'hspace (style-name s))))]))
 
     (define (sanitize-parens str)
       (regexp-replace #rx"[\\(\\)]" str "\\&"))
@@ -273,13 +280,12 @@
             (render-content i part ri))]
 
         [(and (link? i) (not (in-link?)))
-          (let ([link (link-from i)])
-            (display "[")
-            (begin0
-              (parameterize ([in-link? #t])
-                (render-content i part ri))
-              (printf "](~a)" (sanitize-parens link))))]
-
+         (define link (link-from i))
+         (display "[")
+         (begin0
+           (parameterize ([in-link? #t])
+             (render-content i part ri))
+           (printf "](~a)" (sanitize-parens link)))]
         [(and (link-element? i)
               (current-markdown-link-sections)
               (not (in-link?))

--- a/scribble-lib/scribble/private/manual-bib.rkt
+++ b/scribble-lib/scribble/private/manual-bib.rkt
@@ -82,11 +82,11 @@
      (make-table
       bib-style
       (map (lambda (c)
-             (let ([key (a-bib-entry-key c)]
-                   [val (a-bib-entry-val c)])
-               (list
-                (to-flow (make-target-element #f `("[" ,key "]") `(cite ,key)))
-                flow-spacer
-                (to-flow val))))
+             (define key (a-bib-entry-key c))
+             (define val (a-bib-entry-val c))
+             (list
+              (to-flow (make-target-element #f `("[" ,key "]") `(cite ,key)))
+              flow-spacer
+              (to-flow val)))
            citations))))
    null))

--- a/scribble-lib/scribble/private/manual-bind.rkt
+++ b/scribble-lib/scribble/private/manual-bind.rkt
@@ -39,22 +39,22 @@
   (*sig-elem (quote-syntax sig) 'elem))
 
 (define (*sig-elem sig elem #:defn? [defn? #f])
-  (let ([s (to-element/no-color elem)])
-    (make-delayed-element
-     (lambda (renderer sec ri)
-       (let* ([tag (find-scheme-tag sec ri sig #f)]
-              [taglet (and tag (append (cadr tag) (list elem)))]
-              [vtag (and tag `(sig-val ,taglet))]
-              [stag (and tag `(sig-form ,taglet))]
-              [sd (and stag (resolve-get/tentative sec ri stag))])
-         (make-element
-          symbol-color
-          (list
-           (cond [sd (make-link-element (if defn? syntax-def-color syntax-link-color) (list s) stag)]
-                 [vtag (make-link-element (if defn? value-def-color value-link-color) (list s) vtag)]
-                 [else s])))))
-     (lambda () s)
-     (lambda () s))))
+  (define s (to-element/no-color elem))
+  (make-delayed-element
+   (lambda (renderer sec ri)
+     (define tag (find-scheme-tag sec ri sig #f))
+     (define taglet (and tag (append (cadr tag) (list elem))))
+     (define vtag (and tag `(sig-val ,taglet)))
+     (define stag (and tag `(sig-form ,taglet)))
+     (define sd (and stag (resolve-get/tentative sec ri stag)))
+     (make-element
+      symbol-color
+      (list
+       (cond [sd (make-link-element (if defn? syntax-def-color syntax-link-color) (list s) stag)]
+             [vtag (make-link-element (if defn? value-def-color value-link-color) (list s) vtag)]
+             [else s]))))
+   (lambda () s)
+   (lambda () s)))
 
 (define hovers (make-weak-hasheq))
 (define (intern-hover-style text)
@@ -67,21 +67,21 @@
 (define (annote-exporting-library e)
   (make-delayed-element
    (lambda (render p ri)
-     (let ([from (resolve-get/tentative p ri '(exporting-libraries #f))])
-       (if (and from (pair? from))
-           (make-element
-            (intern-hover-style
-             (string-append
-              "Provided from: "
-              (string-join (map ~s from) ", ")
-              (let ([from-pkgs (resolve-get/tentative p ri '(exporting-packages #f))])
-                (if (and from-pkgs (pair? from-pkgs))
-                    (string-append
-                     " | Package: "
-                     (string-join (map ~a from-pkgs) ", "))
-                    ""))))
-            e)
-           e)))
+     (define from (resolve-get/tentative p ri '(exporting-libraries #f)))
+     (if (and from (pair? from))
+         (make-element
+          (intern-hover-style
+           (string-append
+            "Provided from: "
+            (string-join (map ~s from) ", ")
+            (let ([from-pkgs (resolve-get/tentative p ri '(exporting-packages #f))])
+              (if (and from-pkgs (pair? from-pkgs))
+                  (string-append
+                   " | Package: "
+                   (string-join (map ~a from-pkgs) ", "))
+                  ""))))
+          e)
+         e))
    (lambda () e)
    (lambda () e)))
 
@@ -94,13 +94,13 @@
      (proc (or (get-exporting-libraries render part ri) null)))))
 
 (define (definition-site name stx-id form?)
-  (let ([sig (current-signature)])
-    (define (gen defn?)
-      (if sig
-          (*sig-elem #:defn? defn? (sig-id sig) name)
-          ((if defn? annote-exporting-library values)
-           (to-element #:defn? defn? (make-just-context name stx-id)))))
-    (values (gen #t) (gen #f))))
+  (define sig (current-signature))
+  (define (gen defn?)
+    (if sig
+        (*sig-elem #:defn? defn? (sig-id sig) name)
+        ((if defn? annote-exporting-library values)
+         (to-element #:defn? defn? (make-just-context name stx-id)))))
+  (values (gen #t) (gen #f)))
 
 (define checkers (make-hash))
 
@@ -111,26 +111,26 @@
                              (hash-ref
                               checkers lib
                               (lambda ()
-                                (let ([ns-id 
-                                       (let ([ns (make-base-empty-namespace)])
-                                         (parameterize ([current-namespace ns])
-                                           ;; A `(namespace-require `(for-label ,lib))` can
-                                           ;; fail if `lib` provides different bindings of the
-                                           ;; same name at different phases. We can require phases
-                                           ;; 1 and 0 separately, in which case the phase-0
-                                           ;; binding shadows the phase-1 one in that case.
-                                           ;; This strategy only works for documenting bindings
-                                           ;; at phases 0 and 1, though.
-                                           (namespace-require `(just-meta 1 (for-label ,lib)))
-                                           (namespace-require `(just-meta 0 (for-label ,lib)))
-                                           (namespace-syntax-introduce (datum->syntax #f 'x))))])
-                                  (let ([checker
-                                         (lambda (id)
-                                           (free-label-identifier=?
-                                            (datum->syntax ns-id (syntax-e id))
-                                            id))])
-                                    (hash-set! checkers lib checker)
-                                    checker))))])
+                                (define ns-id
+                                  (let ([ns (make-base-empty-namespace)])
+                                    (parameterize ([current-namespace ns])
+                                      ;; A `(namespace-require `(for-label ,lib))` can
+                                      ;; fail if `lib` provides different bindings of the
+                                      ;; same name at different phases. We can require phases
+                                      ;; 1 and 0 separately, in which case the phase-0
+                                      ;; binding shadows the phase-1 one in that case.
+                                      ;; This strategy only works for documenting bindings
+                                      ;; at phases 0 and 1, though.
+                                      (namespace-require `(just-meta 1 (for-label ,lib)))
+                                      (namespace-require `(just-meta 0 (for-label ,lib)))
+                                      (namespace-syntax-introduce (datum->syntax #f 'x)))))
+                                (define checker
+                                  (lambda (id)
+                                    (free-label-identifier=?
+                                     (datum->syntax ns-id (syntax-e id))
+                                     id)))
+                                (hash-set! checkers lib checker)
+                                checker))])
                         (and (checker id) lib)))
                     (or source-libs null))
              (and (pair? libs) (car libs)))])
@@ -144,44 +144,48 @@
   (*id-to-target-maker 'form id dep?))
 
 (define (*id-to-target-maker sym id dep?)
-  (let ([sig (current-signature)])
-    (lambda (content mk)
-      (make-part-relative-element
-       (lambda (ci)
-         (let ([e (ormap (lambda (p)
-                           (ormap (lambda (e)
-                                    (and (exporting-libraries? e) e))
-                                  (part-to-collect p)))
-                         (collect-info-parents ci))])
-           (unless e
-             ;; Call raise-syntax-error to capture error message:
-             (with-handlers ([exn:fail:syntax?
-                              (lambda (exn)
-                                (eprintf "~a\n" (exn-message exn)))])
-               (raise-syntax-error
-                'WARNING
-                "no declared exporting libraries for definition" id)))
-           (if e
-             (let* ([lib-taglet (libs->taglet
-                                 (if sig (sig-id sig) id)
-                                 (exporting-libraries-libs e)
-                                 (exporting-libraries-source-libs e))]
-                    [tag (intern-taglet
-                          (list (if sig
-                                  (case sym
-                                    [(def) 'sig-val]
-                                    [(form) 'sig-def])
-                                  sym)
-                                `(,lib-taglet
-                                  ,@(if sig (list (syntax-e (sig-id sig))) null)
-                                  ,(syntax-e id))))])
-               (if (or sig (not dep?))
-                   (mk tag)
-                   (make-dep (list lib-taglet (syntax-e id))
-                             (mk tag))))
-             content)))
-       (lambda () content)
-       (lambda () content)))))
+  (define sig (current-signature))
+  (lambda (content mk)
+    (make-part-relative-element
+     (lambda (ci)
+       (let ([e (ormap (lambda (p)
+                         (ormap (lambda (e)
+                                  (and (exporting-libraries? e) e))
+                                (part-to-collect p)))
+                       (collect-info-parents ci))])
+         (unless e
+           ;; Call raise-syntax-error to capture error message:
+           (with-handlers ([exn:fail:syntax?
+                            (lambda (exn)
+                              (eprintf "~a\n" (exn-message exn)))])
+             (raise-syntax-error
+              'WARNING
+              "no declared exporting libraries for definition" id)))
+         (cond
+           [e
+            (define lib-taglet
+              (libs->taglet
+               (if sig (sig-id sig) id)
+               (exporting-libraries-libs e)
+               (exporting-libraries-source-libs e)))
+            (define tag
+              (intern-taglet
+               (list (if sig
+                         (case sym
+                           [(def) 'sig-val]
+                           [(form) 'sig-def])
+                         sym)
+                     `(,lib-taglet
+                       ,@(if sig (list (syntax-e (sig-id sig))) null)
+                       ,(syntax-e id)))))
+            (if (or sig (not dep?))
+                (mk tag)
+                (make-dep (list lib-taglet (syntax-e id))
+                          (mk tag)))]
+           [else
+            content])))
+     (lambda () content)
+     (lambda () content))))
 
 (define (defidentifier id 
                        #:form? [form? #f]
@@ -189,78 +193,79 @@
                        #:show-libs? [show-libs? #t])
   ;; This function could have more optional argument to select
   ;; whether to index the id, include a toc link, etc.
-  (let ([dep? #t])
-    (let ([maker (if form?
-                     (id-to-form-target-maker id dep?)
-                     (id-to-target-maker id dep?))])
-      (define-values (elem elem-ref)
-        (if show-libs?
-            (definition-site (syntax-e id) id form?)
-            (values (to-element id #:defn? #t)
-                    (to-element id))))
-      (if maker
-          (maker elem
-                 (lambda (tag)
-                   (let ([elem
-                          (if index?
-                              (make-index-element
-                               #f (list elem) tag
-                               (list (datum-intern-literal (symbol->string (syntax-e id))))
-                               (list elem)
-                               (and show-libs?
-                                    (with-exporting-libraries
-                                     (lambda (libs)
-                                       (make-exported-index-desc (syntax-e id)
-                                                                 libs)))))
-                              elem)])
-                     (make-target-element #f (list elem) tag))))
-          elem))))
+  (define dep? #t)
+  (define maker
+    (if form?
+        (id-to-form-target-maker id dep?)
+        (id-to-target-maker id dep?)))
+  (define-values (elem elem-ref)
+    (if show-libs?
+        (definition-site (syntax-e id) id form?)
+        (values (to-element id #:defn? #t)
+                (to-element id))))
+  (if maker
+      (maker elem
+             (lambda (tag)
+               (let ([elem
+                      (if index?
+                          (make-index-element
+                           #f (list elem) tag
+                           (list (datum-intern-literal (symbol->string (syntax-e id))))
+                           (list elem)
+                           (and show-libs?
+                                (with-exporting-libraries
+                                    (lambda (libs)
+                                      (make-exported-index-desc (syntax-e id)
+                                                                libs)))))
+                          elem)])
+                 (make-target-element #f (list elem) tag))))
+      elem))
 
 (define (make-binding-redirect-elements mod-path redirects)
-  (let ([taglet (module-path-index->taglet 
-                 (module-path-index-join mod-path #f))])
-    (make-element
-     #f
-     (map
-      (lambda (redirect)
-        (let ([id (car redirect)]
-              [form? (cadr redirect)]
-              [path (caddr redirect)]
-              [anchor (cadddr redirect)])
-          (let ([make-one
-                 (lambda (kind)
-                   (make-redirect-target-element
-                    #f
-                    null
-                    (intern-taglet (list kind (list taglet id)))
-                    path
-                    anchor))])
-            (make-element
-             #f
-             (list (make-one (if form? 'form 'def))
-                   (make-dep (list taglet id) null)
-                   (let ([str (datum-intern-literal (symbol->string id))])
-                     (make-index-element #f
-                                         null
-                                         (intern-taglet
-                                          (list (if form? 'form 'def)
-                                                (list taglet id)))
-                                         (list str)
-                                         (list
-                                          (make-element
-                                           symbol-color
-                                           (list
-                                            (make-element
-                                             (if form?
-                                                 syntax-link-color
-                                                 value-link-color)
-                                             (list str)))))
-                                         ((if form?
-                                              make-form-index-desc
-                                              make-procedure-index-desc)
-                                          id
-                                          (list mod-path)))))))))
-      redirects))))
+  (define taglet (module-path-index->taglet 
+                  (module-path-index-join mod-path #f)))
+  (make-element
+   #f
+   (map
+    (lambda (redirect)
+      (define id (car redirect))
+      (define form? (cadr redirect))
+      (define path (caddr redirect))
+      (define anchor (cadddr redirect))
+      (define make-one
+        (lambda (kind)
+          (make-redirect-target-element
+           #f
+           null
+           (intern-taglet (list kind (list taglet id)))
+           path
+           anchor)))
+      (make-element
+       #f
+       (list (make-one (if form? 'form 'def))
+             (make-dep (list taglet id) null)
+             (let ([str (datum-intern-literal (symbol->string id))])
+               (make-index-element #f
+                                   null
+                                   (intern-taglet
+                                    (list (if form? 'form 'def)
+                                          (list taglet id)))
+                                   (list str)
+                                   (list
+                                    (make-element
+                                     symbol-color
+                                     (list
+                                      (make-element
+                                       (if form?
+                                           syntax-link-color
+                                           value-link-color)
+                                       (list str)))))
+                                   ((if form?
+                                        make-form-index-desc
+                                        make-procedure-index-desc)
+                                    id
+                                    (list mod-path)))))))
+    redirects)))
 
 
 (define (make-dep t content)

--- a/scribble-lib/scribble/private/manual-code.rkt
+++ b/scribble-lib/scribble/private/manual-code.rkt
@@ -82,14 +82,14 @@
                                    (substring bstr (cadar tokens) (caddar tokens)))])
                     (cond
                       [(symbol? style)
-                       (let ([scribble-style
-                              (case style
-                                [(symbol) symbol-color]
-                                [(parenthesis hash-colon-keyword) paren-color]
-                                [(constant string) value-color]
-                                [(comment) comment-color]
-                                [else default-color])])
-                         (split-lines scribble-style (get-str)))]
+                       (define scribble-style
+                         (case style
+                           [(symbol) symbol-color]
+                           [(parenthesis hash-colon-keyword) paren-color]
+                           [(constant string) value-color]
+                           [(comment) comment-color]
+                           [else default-color]))
+                       (split-lines scribble-style (get-str))]
                       [(procedure? style)
                        (list (style (get-str)))]
                       [else (list style)]))

--- a/scribble-lib/scribble/private/manual-form.rkt
+++ b/scribble-lib/scribble/private/manual-form.rkt
@@ -300,27 +300,27 @@
 (define (meta-symbol? s) (memq s '(... ...+ ?)))
 
 (define (defform-site kw-id)
-  (let ([target-maker (id-to-form-target-maker kw-id #t)])
-    (define-values (content ref-content) (definition-site (syntax-e kw-id) kw-id #t))
-    (if target-maker
-        (target-maker
-         content
-         (lambda (tag)
-           (make-toc-target2-element
-            #f
-            (if kw-id
-                (make-index-element
-                 #f content tag
-                 (list (datum-intern-literal (symbol->string (syntax-e kw-id))))
-                 (list ref-content)
-                 (with-exporting-libraries
-                  (lambda (libs)
-                    (make-form-index-desc (syntax-e kw-id)
-                                          libs))))
-                content)
-            tag
-            ref-content)))
-        content)))
+  (define target-maker (id-to-form-target-maker kw-id #t))
+  (define-values (content ref-content) (definition-site (syntax-e kw-id) kw-id #t))
+  (if target-maker
+      (target-maker
+       content
+       (lambda (tag)
+         (make-toc-target2-element
+          #f
+          (if kw-id
+              (make-index-element
+               #f content tag
+               (list (datum-intern-literal (symbol->string (syntax-e kw-id))))
+               (list ref-content)
+               (with-exporting-libraries
+                   (lambda (libs)
+                     (make-form-index-desc (syntax-e kw-id)
+                                           libs))))
+              content)
+          tag
+          ref-content)))
+      content))
 
 (define (*defforms kind link? kw-id forms form-procs subs sub-procs contract-procs content-thunk)
   (parameterize ([current-meta-list '(... ...+)])
@@ -416,14 +416,14 @@
   (*racketrawgrammars style (list nonterm) (list (cons clause1 clauses))))
 
 (define (*racketgrammar lits s-expr clauseses-thunk)
-  (let ([l (clauseses-thunk)])
-    (*racketrawgrammars #f
-                        (map (lambda (x)
-                               (make-element #f
-                                             (list (hspace 2)
-                                                   (car x))))
-                             l)
-                        (map cdr l))))
+  (define l (clauseses-thunk))
+  (*racketrawgrammars #f
+                      (map (lambda (x)
+                             (make-element #f
+                                           (list (hspace 2)
+                                                 (car x))))
+                           l)
+                      (map cdr l)))
 
 (define (*var id)
   (to-element (*var-sym id)))

--- a/scribble-lib/scribble/private/manual-method.rkt
+++ b/scribble-lib/scribble/private/manual-method.rkt
@@ -37,8 +37,8 @@
   (if (identifier? id/tag)
       (make-delayed-element
        (λ (ren p ri)
-         (let ([tag (find-scheme-tag p ri id/tag #f)])
-           (if tag (list (mk tag)) content)))
+         (define tag (find-scheme-tag p ri id/tag #f))
+         (if tag (list (mk tag)) content))
        (λ () (car content))
        (λ () (car content)))
       (mk id/tag)))

--- a/scribble-lib/scribble/private/manual-mod.rkt
+++ b/scribble-lib/scribble/private/manual-mod.rkt
@@ -188,19 +188,21 @@
 ;; ----------------------------------------
 
 (define (compute-packages module-path)
-  (let* ([path (with-handlers ([exn:missing-module? (lambda (exn) #f)])
-                 (and module-path
-                      (resolved-module-path-name
-                       (module-path-index-resolve (module-path-index-join module-path #f)))))]
-         [pkg (and path
-                   (path? path)
-                   (or (path->pkg path)
-                       (let ([c (path->main-collects-relative path)])
-                         (and c
-                              "base"))))])
-    (if pkg
-        (list pkg)
-        null)))
+  (define path
+    (with-handlers ([exn:missing-module? (lambda (exn) #f)])
+      (and module-path
+           (resolved-module-path-name
+            (module-path-index-resolve (module-path-index-join module-path #f))))))
+  (define pkg
+    (and path
+         (path? path)
+         (or (path->pkg path)
+             (let ([c (path->main-collects-relative path)])
+               (and c
+                    "base")))))
+  (if pkg
+      (list pkg)
+      null))
 
 ;; mflatt thinks this should not be exposed
 (define (racketpkgname pkg)
@@ -305,14 +307,14 @@
 (define the-reader-index-desc (make-reader-index-desc))
 
 (define (make-defracketmodname mn mp index-desc)
-  (let ([name-str (datum-intern-literal (element->string mn))]
-        [path-str (datum-intern-literal (element->string mp))])
-    (make-index-element #f
-                        (list mn)
-                        (intern-taglet `(mod-path ,path-str))
-                        (list name-str)
-                        (list mn)
-                        index-desc)))
+  (define name-str (datum-intern-literal (element->string mn)))
+  (define path-str (datum-intern-literal (element->string mp)))
+  (make-index-element #f
+                      (list mn)
+                      (intern-taglet `(mod-path ,path-str))
+                      (list name-str)
+                      (list mn)
+                      index-desc))
 
 (define-syntax (declare-exporting stx)
   (syntax-parse stx

--- a/scribble-lib/scribble/private/manual-tech.rkt
+++ b/scribble-lib/scribble/private/manual-tech.rkt
@@ -26,8 +26,8 @@
             . ->* . element?)])
 
 (define (*tech make-elem style doc prefix s key normalize?)
-  (let* ([c (decode-content s)]
-         [s (or key (content->string c))]
+  (define c (decode-content s))
+  (let* ([s (or key (content->string c))]
          [s (if normalize?
                 (let* ([s (string-foldcase s)]
                        [s (regexp-replace #rx"ies$" s "y")]
@@ -39,20 +39,21 @@
     (make-elem style c (list 'tech (doc-prefix doc prefix s)))))
 
 (define (deftech #:style? [style? #t] 
-          #:normalize? [normalize? #t] 
-          #:key [key #f]
-          . s)
-  (let* ([e (if style?
-                (apply defterm s)
-                (make-element #f (decode-content s)))]
-         [t (*tech make-target-element #f #f #f (list e) key normalize?)])
-    (make-index-element #f
-                        (list t)
-                        (target-element-tag t)
-                        (list (datum-intern-literal
-                               (clean-up-index-string (element->string e))))
-                        (list e)
-                        'tech)))
+                 #:normalize? [normalize? #t] 
+                 #:key [key #f]
+                 . s)
+  (define e
+    (if style?
+        (apply defterm s)
+        (make-element #f (decode-content s))))
+  (define t (*tech make-target-element #f #f #f (list e) key normalize?))
+  (make-index-element #f
+                      (list t)
+                      (target-element-tag t)
+                      (list (datum-intern-literal
+                             (clean-up-index-string (element->string e))))
+                      (list e)
+                      'tech))
 
 (define (tech #:doc [doc #f] 
               #:tag-prefixes [prefix #f] 

--- a/scribble-lib/scribble/private/manual-unit.rkt
+++ b/scribble-lib/scribble/private/manual-unit.rkt
@@ -49,19 +49,21 @@
    (lambda ()
      (define in
        (parameterize ([current-signature (make-sig stx-id)]) (body-thunk)))
-     (if indent?
-       (let-values ([(pre-body post-body)
-                     (let loop ([in in][pre-accum null])
-                       (cond [(null? in) (values (reverse pre-accum) null)]
-                             [(whitespace? (car in))
-                              (loop (cdr in) (cons (car in) pre-accum))]
-                             [(sig-desc? (car in))
-                              (loop (cdr in)
-                                    (append (reverse (sig-desc-in (car in)))
-                                            pre-accum))]
-                             [else (values (reverse pre-accum) in)]))])
-         `(,@pre-body
-           ,(make-blockquote
-             "leftindent"
-             (flow-paragraphs (decode-flow post-body)))))
-       in))))
+     (cond
+       [indent?
+        (define-values (pre-body post-body)
+          (let loop ([in in][pre-accum null])
+            (cond [(null? in) (values (reverse pre-accum) null)]
+                  [(whitespace? (car in))
+                   (loop (cdr in) (cons (car in) pre-accum))]
+                  [(sig-desc? (car in))
+                   (loop (cdr in)
+                         (append (reverse (sig-desc-in (car in)))
+                                 pre-accum))]
+                  [else (values (reverse pre-accum) in)])))
+        `(,@pre-body
+          ,(make-blockquote
+            "leftindent"
+            (flow-paragraphs (decode-flow post-body))))]
+       [else
+        in]))))

--- a/scribble-lib/scribble/private/manual-utils.rkt
+++ b/scribble-lib/scribble/private/manual-utils.rkt
@@ -26,11 +26,13 @@
 (define flow-empty-line (to-flow (tt 'nbsp)))
 
 (define (make-table-if-necessary style content)
-  (if (= 1 (length content))
-    (let ([paras (append-map flow-paragraphs (car content))])
-      (if (andmap paragraph? paras)
-        (list (make-omitable-paragraph (append-map paragraph-content paras)))
-        (list (make-table style content))))
-    (list (make-table style content))))
+  (cond
+    [(= 1 (length content))
+     (define paras (append-map flow-paragraphs (car content)))
+     (if (andmap paragraph? paras)
+         (list (make-omitable-paragraph (append-map paragraph-content paras)))
+         (list (make-table style content)))]
+    [else
+     (list (make-table style content))]))
 
 (define current-display-width (make-parameter 65))

--- a/scribble-lib/scribble/private/render-utils.rkt
+++ b/scribble-lib/scribble/private/render-utils.rkt
@@ -11,45 +11,48 @@
 
 (define (select-suffix path suggested-suffixes accepted-suffixes)
   (or (ormap (lambda (suggested)
-               (and (member suggested accepted-suffixes)
-                    (let ([p (bytes->path 
-                              (bytes-append (path->bytes (if (string? path)
-                                                             (string->path path)
-                                                             path))
-                                            (string->bytes/utf-8 suggested)))])
-                      (and (file-exists? p)
-                           p))))
+               (cond
+                 [(not (member suggested accepted-suffixes)) #f]
+                 [else
+                  (define p
+                    (bytes->path 
+                     (bytes-append (path->bytes (if (string? path)
+                                                    (string->path path)
+                                                    path))
+                                   (string->bytes/utf-8 suggested))))
+                  (and (file-exists? p)
+                       p)]))
              suggested-suffixes)
       path))
 
 (define (extract-table-cell-styles t)
-  (let ([vars (style-properties (table-style t))])
-    (or (let ([l (ormap (lambda (v)
-                          (and (table-cells? v)
-                               (table-cells-styless v)))
-                        vars)])
-          (and l
-               (unless (= (length l) (length (table-blockss t)))
-                 (error 'table 
-                        "table-cells property list's length does not match row count: ~e vs. ~e"
-                        l (length (table-blockss t))))
-               (for-each (lambda (l row)
-                           (unless (= (length l) (length row))
-                             (error 'table
-                                    "table-cells property list contains a row whose length does not match the content: ~e vs. ~e"
-                                    l (length row))))
-                         l (table-blockss t))
-               l))
-        (let ([cols (ormap (lambda (v) (and (table-columns? v) v)) vars)])
-          (and cols
-               (let ([cols (table-columns-styles cols)])
-                 (map (lambda (row)
-                        (unless (= (length cols) (length row))
-                          (error 'table
-                                 "table-columns property list's length does not match a row length: ~e vs. ~e"
-                                 cols (length row)))
-                        cols)
-                      (table-blockss t)))))
-        (map (lambda (row) (map (lambda (c) plain) row)) (table-blockss t)))))
+  (define vars (style-properties (table-style t)))
+  (or (let ([l (ormap (lambda (v)
+                        (and (table-cells? v)
+                             (table-cells-styless v)))
+                      vars)])
+        (and l
+             (unless (= (length l) (length (table-blockss t)))
+               (error 'table 
+                      "table-cells property list's length does not match row count: ~e vs. ~e"
+                      l (length (table-blockss t))))
+             (for-each (lambda (l row)
+                         (unless (= (length l) (length row))
+                           (error 'table
+                                  "table-cells property list contains a row whose length does not match the content: ~e vs. ~e"
+                                  l (length row))))
+                       l (table-blockss t))
+             l))
+      (let ([cols (ormap (lambda (v) (and (table-columns? v) v)) vars)])
+        (and cols
+             (let ([cols (table-columns-styles cols)])
+               (map (lambda (row)
+                      (unless (= (length cols) (length row))
+                        (error 'table
+                               "table-columns property list's length does not match a row length: ~e vs. ~e"
+                               cols (length row)))
+                      cols)
+                    (table-blockss t)))))
+      (map (lambda (row) (map (lambda (c) plain) row)) (table-blockss t))))
 
 (define (empty-content? c) (null? c))

--- a/scribble-lib/scribble/render.rkt
+++ b/scribble-lib/scribble/render.rkt
@@ -49,47 +49,49 @@
                 #:quiet? [quiet? #t]
                 #:warn-undefined? [warn-undefined? (not quiet?)])
   (when dest-dir (make-directory* dest-dir))
-  (let ([renderer (new (render-mixin render%)
-                       [dest-dir dest-dir]
-                       [prefix-file prefix-file]
-                       [style-file style-file]
-                       [style-extra-files style-extra-files]
-                       [extra-files extra-files]
-                       [image-preferences image-preferences]
-                       [helper-file-prefix helper-file-prefix])])
-    (when redirect
-      (send renderer set-external-tag-path redirect))
-    (when redirect-main
-      (send renderer set-external-root-url redirect-main))
-    (unless (zero? directory-depth)
-      (send renderer set-directory-depth directory-depth))
-    (unless quiet?
-      (send renderer report-output!))
-    (let* ([fns (map (lambda (fn)
-                       (let-values ([(base name dir?) (split-path fn)])
-                         (let ([fn (path-replace-suffix
-                                    name
-                                    (send renderer get-suffix))])
-                           (if dest-dir (build-path dest-dir fn) fn))))
-                     names)]
-           [fp (send renderer traverse docs fns)]
-           [info (send renderer collect docs fns fp)])
-      (for ([file (in-list info-input-files)])
-        (let ([s (with-input-from-file file read)])
-          (send renderer deserialize-info s info)))
-      (for ([xr (in-list xrefs)])
-        (xref-transfer-info renderer info xr))
-      (let ([r-info (send renderer resolve docs fns info)])
-        (send renderer render docs fns r-info)
-        (when info-output-file
-          (let ([s (send renderer serialize-info r-info)])
-            (with-output-to-file info-output-file
-              #:exists 'truncate/replace
-              (lambda () (write s)))))
-        (when warn-undefined?
-          (let ([undef (send renderer get-undefined r-info)])
-            (unless (null? undef)
-              (eprintf "Warning: some cross references may be broken due to undefined tags:\n")
-              (for ([t (in-list undef)])
-                (eprintf " ~s\n" t))))))
-      (void))))
+  (define renderer
+    (new (render-mixin render%)
+         [dest-dir dest-dir]
+         [prefix-file prefix-file]
+         [style-file style-file]
+         [style-extra-files style-extra-files]
+         [extra-files extra-files]
+         [image-preferences image-preferences]
+         [helper-file-prefix helper-file-prefix]))
+  (when redirect
+    (send renderer set-external-tag-path redirect))
+  (when redirect-main
+    (send renderer set-external-root-url redirect-main))
+  (unless (zero? directory-depth)
+    (send renderer set-directory-depth directory-depth))
+  (unless quiet?
+    (send renderer report-output!))
+  (define fns
+    (map (lambda (fn)
+           (define-values (base name dir?) (split-path fn))
+           (let ([fn (path-replace-suffix
+                      name
+                      (send renderer get-suffix))])
+             (if dest-dir (build-path dest-dir fn) fn)))
+         names))
+  (define fp (send renderer traverse docs fns))
+  (define info (send renderer collect docs fns fp))
+  (for ([file (in-list info-input-files)])
+    (let ([s (with-input-from-file file read)])
+      (send renderer deserialize-info s info)))
+  (for ([xr (in-list xrefs)])
+    (xref-transfer-info renderer info xr))
+  (let ([r-info (send renderer resolve docs fns info)])
+    (send renderer render docs fns r-info)
+    (when info-output-file
+      (let ([s (send renderer serialize-info r-info)])
+        (with-output-to-file info-output-file
+          #:exists 'truncate/replace
+          (lambda () (write s)))))
+    (when warn-undefined?
+      (let ([undef (send renderer get-undefined r-info)])
+        (unless (null? undef)
+          (eprintf "Warning: some cross references may be broken due to undefined tags:\n")
+          (for ([t (in-list undef)])
+            (eprintf " ~s\n" t))))))
+  (void))

--- a/scribble-lib/scribble/run.rkt
+++ b/scribble-lib/scribble/run.rkt
@@ -34,10 +34,10 @@
 (define current-image-prefs        (make-parameter null)) ; reverse order
 
 (define (read-one str)
-  (let ([i (open-input-string str)])
-    (with-handlers ([exn:fail:read? (lambda (x) #f)])
-      (let ([v (read i)])
-        (and (eof-object? (read i)) v)))))
+  (define i (open-input-string str))
+  (with-handlers ([exn:fail:read? (lambda (x) #f)])
+    (let ([v (read i)])
+      (and (eof-object? (read i)) v))))
 
 (define (run)
   (define doc-binding 'doc)
@@ -171,8 +171,8 @@
     (raise-user-error 'scribble "cannot supply a destination name with multiple inputs"))
   (render docs
           (map (lambda (fn)
-                 (let-values ([(base name dir?) (split-path fn)])
-                   (or (current-dest-name) name)))
+                 (define-values (base name dir?) (split-path fn))
+                 (or (current-dest-name) name))
                files)
           #:dest-dir (current-dest-directory)
           #:render-mixin (current-render-mixin)

--- a/scribble-lib/scribble/sigplan/lang.rkt
+++ b/scribble-lib/scribble/sigplan/lang.rkt
@@ -60,25 +60,25 @@ Read here for more:
 |#
 
 (define ((post-process times? qcourier? . opts) doc)
-  (let ([options
-         (if (ormap values opts)
-             (format "[~a]" (apply string-append (add-between (filter values opts) ", ")))
-             "")])
-    (add-sigplan-styles 
-     (add-defaults doc
-                   (string->bytes/utf-8
-                    (format "\\documentclass~a{sigplanconf}\n~a~a~a"
-                            options
-                            unicode-encoding-packages
-                            (if times? 
-                                "\\usepackage{times}\n"
-                                "")
-                            (if qcourier? 
-                                "\\usepackage{qcourier}\n"
-                                "")))
-                   (scribble-file "sigplan/style.tex")
-                   (list (scribble-file "sigplan/sigplanconf.cls"))
-                   #f))))
+  (define options
+    (if (ormap values opts)
+        (format "[~a]" (apply string-append (add-between (filter values opts) ", ")))
+        ""))
+  (add-sigplan-styles 
+   (add-defaults doc
+                 (string->bytes/utf-8
+                  (format "\\documentclass~a{sigplanconf}\n~a~a~a"
+                          options
+                          unicode-encoding-packages
+                          (if times? 
+                              "\\usepackage{times}\n"
+                              "")
+                          (if qcourier? 
+                              "\\usepackage{qcourier}\n"
+                              "")))
+                 (scribble-file "sigplan/style.tex")
+                 (list (scribble-file "sigplan/sigplanconf.cls"))
+                 #f)))
 
 (define (add-sigplan-styles doc)
   ;; Ensure that "sigplan.tex" is used, since "style.tex"

--- a/scribble-lib/scribble/srcdoc.rkt
+++ b/scribble-lib/scribble/srcdoc.rkt
@@ -135,12 +135,12 @@
                                   "not bound as a provide/doc transformer"
                                   stx
                                   #'id))
-                               (let* ([i (make-syntax-introducer)]
-                                      [i2 (lambda (x) (syntax-local-introduce (i x)))])
-                                 (let-values ([(p/c d req/d id)
-                                               ((provide/doc-transformer-proc t)
-                                                (i (syntax-local-introduce form)))])
-                                   (list (i2 p/c) (i req/d) (i d) (i id)))))]
+                               (define i (make-syntax-introducer))
+                               (define i2 (lambda (x) (syntax-local-introduce (i x))))
+                               (let-values ([(p/c d req/d id)
+                                             ((provide/doc-transformer-proc t)
+                                              (i (syntax-local-introduce form)))])
+                                 (list (i2 p/c) (i req/d) (i d) (i id))))]
                             [_
                              (raise-syntax-error
                               #f
@@ -359,44 +359,44 @@
                             
                             (let ([build-mandatories/optionals
                                    (λ (names contracts extras)
-                                     (let ([names-length (length names)]
-                                           [contracts-length (length contracts)])
-                                       (let loop ([contracts contracts]
-                                                  [names names]
-                                                  [extras extras])
-                                         (cond
-                                           [(and (null? names) (null? contracts)) '()]
-                                           [(or (null? names) (null? contracts))
-                                            (raise-syntax-error #f
-                                                                (format "mismatched ~a argument list count and domain contract count (~a)"
-                                                                        (if extras "optional" "mandatory")
-                                                                        (if (null? names)
-                                                                            "ran out of names"
-                                                                            "ran out of contracts"))
-                                                                stx)]
-                                           [else
-                                            (let ([fst-name (car names)]
-                                                  [fst-ctc (car contracts)])
-                                              (if (keyword? (syntax-e fst-ctc))
-                                                  (begin
-                                                    (unless (pair? (cdr contracts))
-                                                      (raise-syntax-error #f
-                                                                          "keyword not followed by a contract"
-                                                                          stx))
-                                                    (cons (if extras
-                                                              (list fst-ctc fst-name (cadr contracts) (car extras))
-                                                              (list fst-ctc fst-name (cadr contracts)))
-                                                          (loop (cddr contracts)
-                                                                (cdr names)
-                                                                (if extras
-                                                                    (cdr extras)
-                                                                    extras))))
-                                                  (cons (if extras 
-                                                            (list fst-name fst-ctc (car extras))
-                                                            (list fst-name fst-ctc))
-                                                        (loop (cdr contracts) (cdr names) (if extras
-                                                                                              (cdr extras)
-                                                                                              extras)))))]))))])
+                                     (define names-length (length names))
+                                     (define contracts-length (length contracts))
+                                     (let loop ([contracts contracts]
+                                                [names names]
+                                                [extras extras])
+                                       (cond
+                                         [(and (null? names) (null? contracts)) '()]
+                                         [(or (null? names) (null? contracts))
+                                          (raise-syntax-error #f
+                                                              (format "mismatched ~a argument list count and domain contract count (~a)"
+                                                                      (if extras "optional" "mandatory")
+                                                                      (if (null? names)
+                                                                          "ran out of names"
+                                                                          "ran out of contracts"))
+                                                              stx)]
+                                         [else
+                                          (define fst-name (car names))
+                                          (define fst-ctc (car contracts))
+                                          (if (keyword? (syntax-e fst-ctc))
+                                              (begin
+                                                (unless (pair? (cdr contracts))
+                                                  (raise-syntax-error #f
+                                                                      "keyword not followed by a contract"
+                                                                      stx))
+                                                (cons (if extras
+                                                          (list fst-ctc fst-name (cadr contracts) (car extras))
+                                                          (list fst-ctc fst-name (cadr contracts)))
+                                                      (loop (cddr contracts)
+                                                            (cdr names)
+                                                            (if extras
+                                                                (cdr extras)
+                                                                extras))))
+                                              (cons (if extras 
+                                                        (list fst-name fst-ctc (car extras))
+                                                        (list fst-name fst-ctc))
+                                                    (loop (cdr contracts) (cdr names) (if extras
+                                                                                          (cdr extras)
+                                                                                          extras))))])))])
                             
                               #`([(id #,@(build-mandatories/optionals (syntax->list #'(mandatory-names ...))
                                                                       (syntax->list #'(mandatory ...))

--- a/scribble-lib/scribble/tag.rkt
+++ b/scribble-lib/scribble/tag.rkt
@@ -48,18 +48,20 @@
   (let ([v (if (list? v)
                (map intern-taglet v)
                (datum-intern-literal v))])
-    (if (or (string? v)
-            (bytes? v)
-            (list? v))
-        (let ([b (hash-ref interned v #f)])
-          (if b
-              (or (weak-box-value b)
-                  ;; just in case the value is GCed before we extract it:
-                  (intern-taglet v))
-              (begin
-                (hash-set! interned v (make-weak-box v))
-                v)))
-        v)))
+    (cond
+      [(or (string? v)
+           (bytes? v)
+           (list? v))
+       (define b (hash-ref interned v #f))
+       (if b
+           (or (weak-box-value b)
+               ;; just in case the value is GCed before we extract it:
+               (intern-taglet v))
+           (begin
+             (hash-set! interned v (make-weak-box v))
+             v))]
+      [else
+       v])))
 
 (define (do-module-path-index->taglet mod)
   ;; Derive the name from the module path:

--- a/scribble-lib/scriblib/footnote.rkt
+++ b/scribble-lib/scriblib/footnote.rkt
@@ -44,27 +44,27 @@
     (define (footnote-part . text) (do-footnote-part footnotes id))))
 
 (define (do-footnote footnotes id text)
-  (let ([tag (generated-tag)]
-        [content (decode-content text)])
-    (make-traverse-element
-     (lambda (get set)
-       (set id (cons (cons
-                      (make-element footnote-target-style
-                                    (make-element
-                                     'superscript
-                                     (counter-target footnotes tag #f)))
-                      content)
-                     (get id null)))
-       (make-element footnote-style
-                     (list
-                      (make-element 
-                       footnote-ref-style
-                       (make-element
-                        'superscript
-                        (counter-ref footnotes tag #f)))
-                      (make-element
-                       footnote-content-style
-                       content)))))))
+  (define tag (generated-tag))
+  (define content (decode-content text))
+  (make-traverse-element
+   (lambda (get set)
+     (set id (cons (cons
+                    (make-element footnote-target-style
+                                  (make-element
+                                   'superscript
+                                   (counter-target footnotes tag #f)))
+                    content)
+                   (get id null)))
+     (make-element footnote-style
+                   (list
+                    (make-element 
+                     footnote-ref-style
+                     (make-element
+                      'superscript
+                      (counter-ref footnotes tag #f)))
+                    (make-element
+                     footnote-content-style
+                     content))))))
 
 (define (do-footnote-part footnotes id)
   (make-part

--- a/scribble-lib/scriblib/gui-eval.rkt
+++ b/scribble-lib/scriblib/gui-eval.rkt
@@ -68,61 +68,66 @@
                                    "exprs.dat"))
 
 (define gui-eval-handler
-  (if mred?
-      (let ([eh (scribble-eval-handler)]
-            [log-file (open-output-file exprs-dat-file #:exists 'truncate/replace)])
-        (λ (gui-eval get-predicate? get-render get-get-width get-get-height)
-          (lambda (ev catching-exns? expr)
-            (write (serialize (if (syntax? expr) (syntax->datum expr) expr)) log-file)
-            (newline log-file)
-            (flush-output log-file)
-            (let ([result
-                   (with-handlers ([exn:fail?
-                                    (lambda (exn)
-                                      (make-gui-exn (exn-message exn)))])
-                     ;; put the call to fixup-picts in the handlers
-                     ;; so that errors in the user-supplied predicates & 
-                     ;; conversion functions show up in the rendered output
-                     (fixup-picts (get-predicate?) (get-render) (get-get-width) (get-get-height)
-                                  (eh ev catching-exns? expr)))])
-              (write (serialize result) log-file)
-              (newline log-file)
-              (flush-output log-file)
-              (if (gui-exn? result)
-                  (raise (make-exn:fail
-                          (gui-exn-message result)
-                          (current-continuation-marks)))
-                  result)))))
-      (let ([log-file (with-handlers ([exn:fail:filesystem?
-                                       (lambda (exn)
-                                         (open-input-string ""))])
-                        (open-input-file exprs-dat-file))])
-        (λ (gui-eval get-predicate? get-render get-get-width get-get-height)
-          (lambda (ev catching-exns? expr)
-            (with-handlers ([exn:fail? (lambda (exn)
-                                         (if catching-exns?
-                                             (raise exn)
-                                             (void)))])
-              (let ([v (read log-file)])
-                (if (eof-object? v)
-                    (error "expression not in log file")
-                    (let ([v (deserialize v)])
-                      (if (equal? v (if (syntax? expr)
-                                        (syntax->datum expr)
-                                        expr))
-                          (let ([v (read log-file)])
-                            (if (eof-object? v)
-                                (error "expression result missing in log file")
-                                (let ([v (deserialize v)])
-                                  (if (gui-exn? v)
-                                      (raise (make-exn:fail
-                                              (gui-exn-message v)
-                                              (current-continuation-marks)))
-                                      v))))
-                          (error 'mreval
-                                 "expression does not match log file: ~e versus: ~e"
-                                 expr
-                                 v)))))))))))
+  (cond
+    [mred?
+     (define eh (scribble-eval-handler))
+     (define log-file (open-output-file exprs-dat-file #:exists 'truncate/replace))
+     (λ (gui-eval get-predicate? get-render get-get-width get-get-height)
+       (lambda (ev catching-exns? expr)
+         (write (serialize (if (syntax? expr) (syntax->datum expr) expr)) log-file)
+         (newline log-file)
+         (flush-output log-file)
+         (define result
+           (with-handlers ([exn:fail?
+                            (lambda (exn)
+                              (make-gui-exn (exn-message exn)))])
+             ;; put the call to fixup-picts in the handlers
+             ;; so that errors in the user-supplied predicates & 
+             ;; conversion functions show up in the rendered output
+             (fixup-picts (get-predicate?) (get-render) (get-get-width) (get-get-height)
+                          (eh ev catching-exns? expr))))
+         (write (serialize result) log-file)
+         (newline log-file)
+         (flush-output log-file)
+         (if (gui-exn? result)
+             (raise (make-exn:fail
+                     (gui-exn-message result)
+                     (current-continuation-marks)))
+             result)))]
+    [else
+     (define log-file
+       (with-handlers ([exn:fail:filesystem?
+                        (lambda (exn)
+                          (open-input-string ""))])
+         (open-input-file exprs-dat-file)))
+     (λ (gui-eval get-predicate? get-render get-get-width get-get-height)
+       (lambda (ev catching-exns? expr)
+         (with-handlers ([exn:fail? (lambda (exn)
+                                      (if catching-exns?
+                                          (raise exn)
+                                          (void)))])
+           (let ([v (read log-file)])
+             (if (eof-object? v)
+                 (error "expression not in log file")
+                 (let ([v (deserialize v)])
+                   (cond
+                     [(equal? v (if (syntax? expr)
+                                    (syntax->datum expr)
+                                    expr))
+                      (define v (read log-file))
+                      (if (eof-object? v)
+                          (error "expression result missing in log file")
+                          (let ([v (deserialize v)])
+                            (if (gui-exn? v)
+                                (raise (make-exn:fail
+                                        (gui-exn-message v)
+                                        (current-continuation-marks)))
+                                v)))]
+                     [else
+                      (error 'mreval
+                             "expression does not match log file: ~e versus: ~e"
+                             expr
+                             v)])))))))]))
 
 (define image-counter 0)
 
@@ -133,41 +138,42 @@
   (let loop ([v v])
     (cond
       [(predicate? v)
-       (let ([fn (build-string-path img-dir
-                                    (format "img~a.png" image-counter))])
-         (set! image-counter (add1 image-counter))
-         (let ([dc (let ([pss (make-object (gui-eval 'ps-setup%))])
-                     (send pss set-mode 'file)
-                     (send pss set-file (path-replace-suffix fn #".pdf"))
-                     (parameterize ([(gui-eval 'current-ps-setup) pss])
-                       (let ([xb (box 0)]
-                             [yb (box 0)])
-                         (send pss get-scaling xb yb)
-                         (new (gui-eval 'pdf-dc%) 
-                              [interactive #f]
-                              [width (* (unbox xb) (get-width v))]
-                              [height (* (unbox yb) (get-height v))]))))])
-           (send dc start-doc "Image")
-           (send dc start-page)
-           (render v dc 0 0)
-           (send dc end-page)
-           (send dc end-doc))
-         (let* ([bm (make-object (gui-eval 'bitmap%)
-                      (inexact->exact (ceiling (get-width v)))
-                      (inexact->exact (ceiling (get-height v))))]
-                [dc (make-object (gui-eval 'bitmap-dc%) bm)])
-           (send dc set-smoothing 'aligned)
-           (send dc clear)
-           (render v dc 0 0)
-           (send bm save-file fn 'png)
-           (make-image-element
-            #f
-            (list "[image]")
-            ;; Be sure to use a string rather than a path, because
-            ;; it gets recorded in "exprs.dat".
-            (path->string (path-replace-suffix fn #""))
-            '(".pdf" ".png")
-            1.0)))]
+       (define fn
+         (build-string-path img-dir
+                            (format "img~a.png" image-counter)))
+       (set! image-counter (add1 image-counter))
+       (let ([dc (let ([pss (make-object (gui-eval 'ps-setup%))])
+                   (send pss set-mode 'file)
+                   (send pss set-file (path-replace-suffix fn #".pdf"))
+                   (parameterize ([(gui-eval 'current-ps-setup) pss])
+                     (let ([xb (box 0)]
+                           [yb (box 0)])
+                       (send pss get-scaling xb yb)
+                       (new (gui-eval 'pdf-dc%) 
+                            [interactive #f]
+                            [width (* (unbox xb) (get-width v))]
+                            [height (* (unbox yb) (get-height v))]))))])
+         (send dc start-doc "Image")
+         (send dc start-page)
+         (render v dc 0 0)
+         (send dc end-page)
+         (send dc end-doc))
+       (let* ([bm (make-object (gui-eval 'bitmap%)
+                    (inexact->exact (ceiling (get-width v)))
+                    (inexact->exact (ceiling (get-height v))))]
+              [dc (make-object (gui-eval 'bitmap-dc%) bm)])
+         (send dc set-smoothing 'aligned)
+         (send dc clear)
+         (render v dc 0 0)
+         (send bm save-file fn 'png)
+         (make-image-element
+          #f
+          (list "[image]")
+          ;; Be sure to use a string rather than a path, because
+          ;; it gets recorded in "exprs.dat".
+          (path->string (path-replace-suffix fn #""))
+          '(".pdf" ".png")
+          1.0))]
       [(pair? v) (cons (loop (car v))
                        (loop (cdr v)))]
       [(serializable? v) v]

--- a/scribble-lib/scriblib/private/counter.rkt
+++ b/scribble-lib/scriblib/private/counter.rkt
@@ -36,15 +36,15 @@
          (list
           (make-delayed-element
            (lambda (renderer part ri)
-             (let ([n (resolve-get part ri (tag->counter-tag counter tag "value"))])
-               (cons
-                (make-element label-style
-                              (let ([l (cons (make-element (default-figure-counter-style) (format "~a" n))
-                                             (decode-content (list label-suffix)))])
-                                (if label
-                                    (list* label 'nbsp l)
-                                    l)))
-                content)))
+             (define n (resolve-get part ri (tag->counter-tag counter tag "value")))
+             (cons
+              (make-element label-style
+                            (let ([l (cons (make-element (default-figure-counter-style) (format "~a" n))
+                                           (decode-content (list label-suffix)))])
+                              (if label
+                                  (list* label 'nbsp l)
+                                  l)))
+              content))
            (lambda () (if label
                           (list* label 'nbsp "N" content)
                           (cons "N" content)))
@@ -52,11 +52,12 @@
                           (list* label 'nbsp "N" content)
                           (cons "N" content)))))
          (lambda (ci)
-           (let ([n (if continue?
-                        (counter-n counter)
-                        (add1 (counter-n counter)))])
-             (set-counter-n! counter n)
-             (collect-put! ci (generate-tag (tag->counter-tag counter tag "value") ci) n)))))
+           (define n
+             (if continue?
+                 (counter-n counter)
+                 (add1 (counter-n counter))))
+           (set-counter-n! counter n)
+           (collect-put! ci (generate-tag (tag->counter-tag counter tag "value") ci) n))))
        (tag->counter-tag counter tag)))
     (if (counter-target-wrap counter)
         ((counter-target-wrap counter)

--- a/scribble-test/tests/scribble/docs.rkt
+++ b/scribble-test/tests/scribble/docs.rkt
@@ -17,16 +17,17 @@
                              "scribble-docs-tests"))
 
 (define (build-doc render% src-file dest-file)
-  (let* ([renderer (new render% [dest-dir work-dir])]
-         [docs     (list (if (module-declared? `(submod ,src-file doc) #t)
-                             (dynamic-require `(submod ,src-file doc) 'doc)
-                             (dynamic-require src-file 'doc)))]
-         [fns      (list (build-path work-dir dest-file))]
-         [fp       (send renderer traverse docs fns)]
-         [info     (send renderer collect  docs fns fp)]
-         [r-info   (send renderer resolve  docs fns info)])
-    (send renderer render docs fns r-info)
-    (send renderer get-undefined r-info)))
+  (define renderer (new render% [dest-dir work-dir]))
+  (define docs
+    (list (if (module-declared? `(submod ,src-file doc) #t)
+              (dynamic-require `(submod ,src-file doc) 'doc)
+              (dynamic-require src-file 'doc))))
+  (define fns (list (build-path work-dir dest-file)))
+  (define fp (send renderer traverse docs fns))
+  (define info (send renderer collect  docs fns fp))
+  (define r-info (send renderer resolve  docs fns info))
+  (send renderer render docs fns r-info)
+  (send renderer get-undefined r-info))
 
 (define (build-text-doc src-file dest-file)
   (build-doc (text:render-mixin render%) src-file dest-file))

--- a/scribble-test/tests/scribble/markdown.rkt
+++ b/scribble-test/tests/scribble/markdown.rkt
@@ -10,14 +10,14 @@
                              "scribble-docs-tests"))
 
 (define (build-markdown-doc src-file dest-file)
-  (let* ([renderer (new (markdown:render-mixin render%) [dest-dir work-dir])]
-         [docs     (list (dynamic-require src-file 'doc))]
-         [fns      (list (build-path work-dir dest-file))]
-         [fp       (send renderer traverse docs fns)]
-         [info     (send renderer collect  docs fns fp)]
-         [r-info   (send renderer resolve  docs fns info)])
-    (send renderer render docs fns r-info)
-    (send renderer get-undefined r-info)))
+  (define renderer (new (markdown:render-mixin render%) [dest-dir work-dir]))
+  (define docs (list (dynamic-require src-file 'doc)))
+  (define fns (list (build-path work-dir dest-file)))
+  (define fp (send renderer traverse docs fns))
+  (define info (send renderer collect  docs fns fp))
+  (define r-info (send renderer resolve  docs fns info))
+  (send renderer render docs fns r-info)
+  (send renderer get-undefined r-info))
 
 (provide markdown-tests)
 (module+ main (markdown-tests))

--- a/scribble-test/tests/scribble/reader.rkt
+++ b/scribble-test/tests/scribble/reader.rkt
@@ -825,8 +825,8 @@ END-OF-TESTS
   (if whole?
     (reader i)
     (let loop ()
-      (let ([x (reader i)])
-        (if (eof-object? x) '() (cons x (loop)))))))
+      (define x (reader i))
+      (if (eof-object? x) '() (cons x (loop))))))
 
 (define read/BS (scr:make-at-reader #:command-char #\\ #:syntax? #f))
 (define read-syntax/BS (scr:make-at-reader #:command-char #\\ #:syntax? #t))
@@ -944,15 +944,16 @@ END-OF-TESTS
                                      t)
                        (regexp-match #px"^(.*\\S)\\s+(-\\S+->)\\s+(\\S.*)$"
                                      t))])
-            (if (not (and m (= 4 (length m))))
-              (error 'bad-test "~a" t)
-              (let-values ([(x y)
-                            ((string->tester (caddr m)) (cadr m) (cadddr m))])
-                (test #:failure-message
-                      (format "bad result in\n    ~a\n  results:\n    ~s != ~s"
-                              (regexp-replace* #rx"\n" t "\n    ")
-                              x y)
-                      (matching? x y))))))))
+            (cond
+              [(not (and m (= 4 (length m))))
+               (error 'bad-test "~a" t)]
+              [else
+               (define-values (x y) ((string->tester (caddr m)) (cadr m) (cadddr m)))
+               (test #:failure-message
+                     (format "bad result in\n    ~a\n  results:\n    ~s != ~s"
+                             (regexp-replace* #rx"\n" t "\n    ")
+                             x y)
+                     (matching? x y))])))))
 
     ;; Check static versus dynamic readtable for command (dynamic when "c" in the
     ;; name) and datum (dynamic when "d" in the name) parts:

--- a/scribble-text-lib/scribble/text/syntax-utils.rkt
+++ b/scribble-text-lib/scribble/text/syntax-utils.rkt
@@ -24,15 +24,19 @@
   (define (group-by pred? xs fun)
     (let loop ([xs xs] [before '()] [cur #f] [after '()] [r '()])
       (define (add) (cons (fun (reverse before) cur (reverse after)) r))
-      (if (null? xs)
-        (reverse (if (or cur (pair? before) (pair? after)) (add) r))
-        (let* ([x (car xs)] [xs (cdr xs)] [p (pred? x)])
-          (cond [(eq? '> p) (loop xs before cur (cons x after) r)]
-                [(eq? '< p) (if (or cur (pair? after))
-                              (loop xs (list x) #f '() (add))
-                              (loop xs (cons x before) cur after r))]
-                [(or cur (pair? after)) (loop xs '() x '() (add))]
-                [else (loop xs before x '() r)])))))
+      (cond
+        [(null? xs)
+         (reverse (if (or cur (pair? before) (pair? after)) (add) r))]
+        [else
+         (define x (car xs))
+         (let ([xs (cdr xs)])
+           (define p (pred? x))
+           (cond [(eq? '> p) (loop xs before cur (cons x after) r)]
+                 [(eq? '< p) (if (or cur (pair? after))
+                                 (loop xs (list x) #f '() (add))
+                                 (loop xs (cons x before) cur after r))]
+                 [(or cur (pair? after)) (loop xs '() x '() (add))]
+                 [else (loop xs before x '() r)]))])))
   (define (group-stxs stxs fun)
     (group-by (λ (stx)
                 (define p (syntax-property stx 'scribble))

--- a/scribble-text-lib/scribble/text/wrap.rkt
+++ b/scribble-text-lib/scribble/text/wrap.rkt
@@ -59,10 +59,11 @@
       (define word (substring str w1* w2*))
       (define-values [r1 r2 r3]
         (if split-word (split-word word (- width w1*)) (values #f word #t)))
-      (let* ([1st (cond [r1 (string-append (substring str 0 w1*) r1)]
-                        [(eq? w1* 0) #f]
-                        [else (substring str 0 s1)])]
-             [strs (if 1st (cons 1st strs) strs)]
+      (define 1st
+        (cond [r1 (string-append (substring str 0 w1*) r1)]
+              [(eq? w1* 0) #f]
+              [else (substring str 0 s1)]))
+      (let* ([strs (if 1st (cons 1st strs) strs)]
              [width* (cond [(not r1) width*]
                            [(pair? width*) (cdr width*)]
                            [else width*])]
@@ -73,11 +74,12 @@
              [strs (if 2nd (cons 2nd strs) strs)]
              [width* (cond [(not r2) width*]
                            [(pair? width*) (cdr width*)]
-                           [else width*])]
-             [rst (cond [(and (not 2nd) r2)
-                         (string-append r2 (substring str w2*))]
-                        [(eq? w2* strlen) #f]
-                        [else (substring str s2)])])
+                           [else width*])])
+        (define rst
+          (cond [(and (not 2nd) r2)
+                 (string-append r2 (substring str w2*))]
+                [(eq? w2* strlen) #f]
+                [else (substring str s2)]))
         (if rst (loop rst strs width*) (reverse strs))))
     (cond
       [(strlen . <= . width) (reverse (cons str strs))]


### PR DESCRIPTION
This pull request was generated by the automated refactoring tool [`resyntax`](https://github.com/jackfirth/resyntax). It replaces uses of `let` forms with `define` forms, when doing so would decrease nesting and wouldn't change the existing binding structure. Some replacements were not made because `resyntax` isn't always able to preserve comments in the original code.

This is a larger-scale version of #289. While that pull request touched a single file, this one attempts to clean up the entire repository. I can split it into smaller, easier-to-review chunks if preferred. Each file's changes are independent and can be reverted independently, so it should hopefully be easy to undo any mistakes here.