### PR TITLE
Replace uses of define-struct with struct

### DIFF
--- a/scribble-lib/scribble/base-render.rkt
+++ b/scribble-lib/scribble/base-render.rkt
@@ -1197,8 +1197,9 @@
 
 ;; ----------------------------------------
 
-(define-struct demand-chain ([demands #:mutable])
+(struct demand-chain ([demands #:mutable])
   #:property prop:procedure (lambda (self key ci)
                               (for/or ([demand (in-list (demand-chain-demands self))])
-                                (demand key ci))))
+                                (demand key ci)))
+  #:extra-constructor-name make-demand-chain)
 

--- a/scribble-lib/scribble/base.rkt
+++ b/scribble-lib/scribble/base.rkt
@@ -180,7 +180,8 @@
                    (loop (append (car items) (cdr items)))]))])
     (make-itemization (convert-block-style style) flows)))
 
-(define-struct an-item (flow))
+(struct an-item (flow)
+  #:extra-constructor-name make-an-item)
 
 (define (item . str)
   (make-an-item (decode-flow str)))

--- a/scribble-lib/scribble/core.rkt
+++ b/scribble-lib/scribble/core.rkt
@@ -6,8 +6,10 @@
 
 ;; ----------------------------------------
 
-(define-struct collect-info (fp ht ext-ht ext-demand parts tags gen-prefix relatives parents) #:transparent)
-(define-struct resolve-info (ci delays undef searches) #:transparent)
+(struct collect-info (fp ht ext-ht ext-demand parts tags gen-prefix relatives parents) #:transparent
+  #:extra-constructor-name make-collect-info)
+(struct resolve-info (ci delays undef searches) #:transparent
+  #:extra-constructor-name make-resolve-info)
 
 (define (part-collected-info part ri)
   (hash-ref (collect-info-parts (resolve-info-ci ri))
@@ -319,7 +321,7 @@
 ;; ----------------------------------------
 
 ;; Traverse block has special serialization support:
-(define-struct traverse-block (traverse)
+(struct traverse-block (traverse)
   #:property
   prop:serializable
   (make-serialize-info
@@ -332,7 +334,8 @@
    #'deserialize-traverse-block
    #f
    (or (current-load-relative-directory) (current-directory)))
-  #:transparent)
+  #:transparent
+  #:extra-constructor-name make-traverse-block)
 
 (define block-traverse-procedure/c
   (recursive-contract
@@ -369,7 +372,7 @@
 ;; ----------------------------------------
 
 ;; Traverse element has special serialization support:
-(define-struct traverse-element (traverse)
+(struct traverse-element (traverse)
   #:property
   prop:serializable
   (make-serialize-info
@@ -382,7 +385,8 @@
    #'deserialize-traverse-element
    #f
    (or (current-load-relative-directory) (current-directory)))
-  #:transparent)
+  #:transparent
+  #:extra-constructor-name make-traverse-element)
 
 (define element-traverse-procedure/c
   (recursive-contract
@@ -419,7 +423,7 @@
 ;; ----------------------------------------
 
 ;; Delayed element has special serialization support:
-(define-struct delayed-element (resolve sizer plain)
+(struct delayed-element (resolve sizer plain)
   #:property
   prop:serializable
   (make-serialize-info
@@ -437,7 +441,8 @@
    #'deserialize-delayed-element
    #f
    (or (current-load-relative-directory) (current-directory)))
-  #:transparent)
+  #:transparent
+  #:extra-constructor-name make-delayed-element)
 
 (provide/contract
  (struct delayed-element ([resolve (any/c part? resolve-info? . -> . content?)]
@@ -463,7 +468,7 @@
 ;; ----------------------------------------
 
 ;; part-relative element has special serialization support:
-(define-struct part-relative-element (collect sizer plain)
+(struct part-relative-element (collect sizer plain)
   #:property
   prop:serializable
   (make-serialize-info
@@ -482,7 +487,8 @@
    #'deserialize-part-relative-element
    #f
    (or (current-load-relative-directory) (current-directory)))
-  #:transparent)
+  #:transparent
+  #:extra-constructor-name make-part-relative-element)
 
 (provide/contract
  (struct part-relative-element ([collect (collect-info? . -> . content?)]
@@ -506,7 +512,7 @@
 
 ;; Delayed index entry also has special serialization support.
 ;; It uses the same delay -> value table as delayed-element
-(define-struct delayed-index-desc (resolve)
+(struct delayed-index-desc (resolve)
   #:mutable
   #:property
   prop:serializable 
@@ -526,7 +532,8 @@
    #'deserialize-delayed-index-desc
    #f
    (or (current-load-relative-directory) (current-directory)))
-  #:transparent)
+  #:transparent
+  #:extra-constructor-name make-delayed-index-desc)
 
 (provide/contract
  (struct delayed-index-desc ([resolve (any/c part? resolve-info? . -> . any)])))
@@ -538,7 +545,7 @@
 
 ;; ----------------------------------------
 
-(define-struct (collect-element element) (collect)
+(struct collect-element element (collect)
   #:mutable
   #:property
   prop:serializable
@@ -550,7 +557,8 @@
    #'deserialize-collect-element
    #f
    (or (current-load-relative-directory) (current-directory)))
-  #:transparent)
+  #:transparent
+  #:extra-constructor-name make-collect-element)
 
 (module+ deserialize-info
   (provide deserialize-collect-element))
@@ -564,7 +572,7 @@
 
 ;; ----------------------------------------
 
-(define-struct (render-element element) (render)
+(struct render-element element (render)
   #:property
   prop:serializable
   (make-serialize-info
@@ -575,7 +583,8 @@
    #'deserialize-render-element
    #f
    (or (current-load-relative-directory) (current-directory)))
-  #:transparent)
+  #:transparent
+  #:extra-constructor-name make-render-element)
 
 (module+ deserialize-info
   (provide deserialize-render-element))
@@ -589,7 +598,7 @@
 
 ;; ----------------------------------------
 
-(define-struct generated-tag ()
+(struct generated-tag ()
   #:property
   prop:serializable
   (make-serialize-info
@@ -600,13 +609,14 @@
                 "current-serialize-resolve-info not set"))
        (let ([t (hash-ref (collect-info-tags (resolve-info-ci ri)) g #f)])
          (if t
-           (vector t)
-           (error 'serialize-generated-tag
-                  "serialization failed (wrong resolve info?)")))))
+             (vector t)
+             (error 'serialize-generated-tag
+                    "serialization failed (wrong resolve info?)")))))
    #'deserialize-generated-tag
    #f
    (or (current-load-relative-directory) (current-directory)))
-  #:transparent)
+  #:transparent
+  #:extra-constructor-name make-generated-tag)
 
 (provide (struct-out generated-tag))
 

--- a/scribble-lib/scribble/private/manual-bib.rkt
+++ b/scribble-lib/scribble/private/manual-bib.rkt
@@ -9,7 +9,8 @@
          "manual-utils.rkt"
          "manual-style.rkt")
 
-(define-struct a-bib-entry (key val))
+(struct a-bib-entry (key val)
+  #:extra-constructor-name make-a-bib-entry)
 
 (provide/contract
  [cite ((string?) () #:rest (listof string?) . ->* . element?)]

--- a/scribble-lib/scribble/private/manual-bind.rkt
+++ b/scribble-lib/scribble/private/manual-bind.rkt
@@ -33,7 +33,8 @@
 (define (gen-absolute-tag)
   `(abs ,(make-generated-tag)))
 
-(define-struct sig (id))
+(struct sig (id)
+  #:extra-constructor-name make-sig)
 
 (define-syntax-rule (sigelem sig elem)
   (*sig-elem (quote-syntax sig) 'elem))

--- a/scribble-lib/scribble/private/manual-class.rkt
+++ b/scribble-lib/scribble/private/manual-class.rkt
@@ -40,11 +40,16 @@
 
 (define-syntax-parameter current-class #f)
 
-(define-struct decl (name super app-mixins intfs ranges mk-head body))
-(define-struct constructor (def))
-(define-struct meth (names mode def))
-(define-struct spec (def))
-(define-struct impl (def))
+(struct decl (name super app-mixins intfs ranges mk-head body)
+  #:extra-constructor-name make-decl)
+(struct constructor (def)
+  #:extra-constructor-name make-constructor)
+(struct meth (names mode def)
+  #:extra-constructor-name make-meth)
+(struct spec (def)
+  #:extra-constructor-name make-spec)
+(struct impl (def)
+  #:extra-constructor-name make-impl)
 
 (define (id-info id)
   (let ([b (identifier-label-binding id)])

--- a/scribble-lib/scribble/private/manual-ex.rkt
+++ b/scribble-lib/scribble/private/manual-ex.rkt
@@ -5,6 +5,7 @@
 (provide (struct-out exporting-libraries)
          current-signature)
 
-(define-struct (exporting-libraries element) (libs source-libs pkgs))
+(struct exporting-libraries element (libs source-libs pkgs)
+  #:extra-constructor-name make-exporting-libraries)
 
 (define current-signature (make-parameter #f))

--- a/scribble-lib/scribble/private/manual-proc.rkt
+++ b/scribble-lib/scribble/private/manual-proc.rkt
@@ -211,8 +211,8 @@
                     (lambda () (list desc ...))
                     (list (result-value value.value) ...)))))]))
 
-(define-struct arg
-  (special? kw id optional? starts-optional? ends-optional? depth))
+(struct arg (special? kw id optional? starts-optional? ends-optional? depth)
+  #:extra-constructor-name make-arg)
 
 (define (*defproc kind link? mode within-id
                   stx-ids sym prototypes arg-contractss arg-valss result-contracts content-thunk

--- a/scribble-lib/scribble/private/manual-unit.rkt
+++ b/scribble-lib/scribble/private/manual-unit.rkt
@@ -31,7 +31,8 @@
                   (lambda () (list body ...))
                   #f)))
 
-(define-struct sig-desc (in))
+(struct sig-desc (in)
+  #:extra-constructor-name make-sig-desc)
 (define (signature-desc . l)
   (make-sig-desc l))
 

--- a/scribble-lib/scribble/private/manual-vars.rkt
+++ b/scribble-lib/scribble/private/manual-vars.rkt
@@ -15,7 +15,8 @@
          (for-label racket/base
                     racket/class))
 
-(define-struct (box-splice splice) ())
+(struct box-splice splice ()
+  #:extra-constructor-name make-box-splice)
 
 (provide/contract
  [struct (box-splice splice) ([run list?])]) ; XXX ugly copying
@@ -70,7 +71,8 @@
                           (cons (attributes '((class . "RForeground")))
                                 p)))))))))
 
-(begin-for-syntax (define-struct deftogether-tag () #:omit-define-syntaxes))
+(begin-for-syntax (struct deftogether-tag () #:omit-define-syntaxes
+                    #:extra-constructor-name make-deftogether-tag))
 
 (define-syntax (with-togetherable-racket-variables stx)
   (syntax-case stx ()

--- a/scribble-lib/scribble/racket.rkt
+++ b/scribble-lib/scribble/racket.rkt
@@ -103,9 +103,11 @@
 
 (define defined-names (make-hasheq))
 
-(define-struct (sized-element element) (length))
+(struct sized-element element (length)
+  #:extra-constructor-name make-sized-element)
 
-(define-struct (spaces element) (cnt))
+(struct spaces element (cnt)
+  #:extra-constructor-name make-spaces)
 
 ;; We really don't want leading hypens (or minus signs) to
 ;; create a line break after the hyphen. For interior hyphens,
@@ -144,8 +146,10 @@
 (define id-element-cache (make-weak-hash))
 (define element-cache (make-weak-hash))
 
-(define-struct (cached-delayed-element delayed-element) (cache-key))
-(define-struct (cached-element element) (cache-key))
+(struct cached-delayed-element delayed-element (cache-key)
+  #:extra-constructor-name make-cached-delayed-element)
+(struct cached-element element (cache-key)
+  #:extra-constructor-name make-cached-element)
 
 (define qq-ellipses (string->uninterned-symbol "..."))
 
@@ -954,7 +958,7 @@
   (typeset c #t pfx1 pfx sfx color? expr? escapes? #f elem-wrap))
 
 (begin-for-syntax 
-  (define-struct variable-id (sym) 
+  (struct variable-id (sym) 
     #:omit-define-syntaxes
     #:property prop:procedure (lambda (self stx)
                                 (raise-syntax-error
@@ -962,8 +966,9 @@
                                  (string-append
                                   "misuse of an identifier (not in `racket', etc.) that is"
                                   " bound as a code-typesetting variable")
-                                 stx)))
-  (define-struct element-id-transformer (proc) 
+                                 stx))
+    #:extra-constructor-name make-variable-id)
+  (struct element-id-transformer (proc) 
     #:omit-define-syntaxes
     #:property prop:procedure (lambda (self stx)
                                 (raise-syntax-error
@@ -971,7 +976,8 @@
                                  (string-append
                                   "misuse of an identifier (not in `racket', etc.) that is"
                                   " bound as an code-typesetting element transformer")
-                                 stx))))
+                                 stx))
+    #:extra-constructor-name make-element-id-transformer))
 
 (define-syntax (define-code stx)
   (syntax-case stx ()
@@ -1080,16 +1086,25 @@
                         (loop (cons (car r) r) (sub1 i)))))
          l))))
 
-(define-struct var-id (sym))
-(define-struct shaped-parens (val shape))
-(define-struct long-boolean (val))
-(define-struct just-context (val ctx))
-(define-struct alternate-display (id string))
-(define-struct literal-syntax (stx))
-(define-struct struct-proxy (name content))
+(struct var-id (sym)
+  #:extra-constructor-name make-var-id)
+(struct shaped-parens (val shape)
+  #:extra-constructor-name make-shaped-parens)
+(struct long-boolean (val)
+  #:extra-constructor-name make-long-boolean)
+(struct just-context (val ctx)
+  #:extra-constructor-name make-just-context)
+(struct alternate-display (id string)
+  #:extra-constructor-name make-alternate-display)
+(struct literal-syntax (stx)
+  #:extra-constructor-name make-literal-syntax)
+(struct struct-proxy (name content)
+  #:extra-constructor-name make-struct-proxy)
 
-(define-struct graph-reference (bx))
-(define-struct graph-defn (r bx))
+(struct graph-reference (bx)
+  #:extra-constructor-name make-graph-reference)
+(struct graph-defn (r bx)
+  #:extra-constructor-name make-graph-defn)
 
 (define (syntax-ize v col [line 1] #:expr? [expr? #f])
   (do-syntax-ize v col line (box #hasheq()) #f (and expr? 0) #f))
@@ -1100,7 +1115,8 @@
          (set-box! ht (hash-set (unbox ht) '#%graph-count (add1 n)))
          n)))
 
-(define-struct forced-pair (car cdr))
+(struct forced-pair (car cdr)
+  #:extra-constructor-name make-forced-pair)
 
 (define (quotable? v)
   (define graph (make-hasheq))

--- a/scribble-lib/scribble/srcdoc.rkt
+++ b/scribble-lib/scribble/srcdoc.rkt
@@ -182,12 +182,13 @@
           provide/doc-transformer-proc))
 
 (begin-for-syntax
- (define-struct provide/doc-transformer (proc)
-   #:property 
-   prop:provide-pre-transformer
-   (lambda (self)
-     (lambda (stx mode)
-       (do-provide/doc stx mode)))))
+ (struct provide/doc-transformer (proc)
+    #:property 
+    prop:provide-pre-transformer
+    (lambda (self)
+      (lambda (stx mode)
+        (do-provide/doc stx mode)))
+    #:extra-constructor-name make-provide/doc-transformer))
 
 (define-syntax-rule (define-provide/doc-transformer id rhs)
   (define-syntax id

--- a/scribble-lib/scribble/xref.rkt
+++ b/scribble-lib/scribble/xref.rkt
@@ -28,11 +28,14 @@
    tag      ; for generating a Scribble link
    desc))   ; further info that depends on the kind of index entry
 
-(define-struct data+root (data root))
-(define-struct (data+root+doc-id data+root) (doc-id))
+(struct data+root (data root)
+  #:extra-constructor-name make-data+root)
+(struct data+root+doc-id data+root (doc-id)
+  #:extra-constructor-name make-data+root+doc-id)
 
 ;; Private:
-(define-struct xrefs (renderer ri))
+(struct xrefs (renderer ri)
+  #:extra-constructor-name make-xrefs)
 
 (define (xref? x) (xrefs? x))
 

--- a/scribble-lib/scriblib/private/counter.rkt
+++ b/scribble-lib/scriblib/private/counter.rkt
@@ -8,7 +8,8 @@
          counter-ref
          counter-collect-value)
 
-(define-struct counter ([n #:mutable] name target-wrap ref-wrap))
+(struct counter ([n #:mutable] name target-wrap ref-wrap)
+  #:extra-constructor-name make-counter)
 
 (define (new-counter name
                      #:target-wrap [target-wrap (lambda (c s) c)]

--- a/scribble-test/tests/scribble/docs/manual-ex.rkt
+++ b/scribble-test/tests/scribble/docs/manual-ex.rkt
@@ -16,7 +16,8 @@
 (define p (make-parameter 10))
 (define q (make-parameter #f))
 
-(define-struct pt (x y))
+(struct pt (x y)
+  #:extra-constructor-name make-pt)
 (struct pn (x y))
 
 (define v 10)

--- a/scribble-text-lib/scribble/text/output.rkt
+++ b/scribble-text-lib/scribble/text/output.rkt
@@ -251,7 +251,8 @@
 
 ;; special constructs
 
-(define-struct special (flag contents))
+(struct special (flag contents)
+  #:extra-constructor-name make-special)
 
 (define-syntax define/provide-special
   (syntax-rules ()


### PR DESCRIPTION
The `define-struct` form is a legacy form, `struct` is preferred in new code.

Note: these changes were automatically generated by [`resyntax`](https://github.com/jackfirth/resyntax).