### PR TITLE
Make navbar stick and scrollable

### DIFF
--- a/scribble-lib/scribble/manual-style.css
+++ b/scribble-lib/scribble/manual-style.css
@@ -194,7 +194,6 @@ a:hover {
     position: fixed;
     z-index: 1;
     background: #a7b0be;
-    height: auto;
     top: 0;
     left: 0;
     margin-bottom: 0;

--- a/scribble-lib/scribble/manual-style.css
+++ b/scribble-lib/scribble/manual-style.css
@@ -428,9 +428,9 @@ a:hover {
     left: 0;
     top: 0rem;
     width: 14rem;
-    padding: 7rem 0.5rem 0.5rem 0.5rem;
+    padding: 0rem 0.5rem 0.5rem 0.5rem;
     background-color: hsl(216, 15%, 70%);
-    margin: 0;
+    margin: 6rem 0 0 0;
 
 }
 

--- a/scribble-lib/scribble/manual-style.css
+++ b/scribble-lib/scribble/manual-style.css
@@ -191,7 +191,10 @@ a:hover {
 }
 
 .navsettop {
-    position: absolute;
+    position: fixed;
+    z-index: 1;
+    background: #a7b0be;
+    height: auto;
     top: 0;
     left: 0;
     margin-bottom: 0;
@@ -418,7 +421,9 @@ a:hover {
 /* Table of contents, left margin */
 
 .tocset {
-    position: absolute;
+    position: fixed;
+    overflow-y: scroll;
+    height: 88%;
     float: none;
     left: 0;
     top: 0rem;

--- a/scribble-lib/scribble/manual-style.css
+++ b/scribble-lib/scribble/manual-style.css
@@ -423,10 +423,10 @@ a:hover {
 .tocset {
     position: fixed;
     overflow-y: scroll;
-    height: 88%;
     float: none;
     left: 0;
     top: 0rem;
+    bottom: 0;
     width: 14rem;
     padding: 0rem 0.5rem 0.5rem 0.5rem;
     background-color: hsl(216, 15%, 70%);


### PR DESCRIPTION
This helps with navigation of long docs pages. For an example, see:
https://www.students.cs.ubc.ca/~cs-411/docs/reference/sets.html?q=sets