### PR TITLE
Fix some overflows issues caused by the sticky navigation bar

### DIFF
--- a/scribble-lib/scribble/manual-style.css
+++ b/scribble-lib/scribble/manual-style.css
@@ -198,7 +198,6 @@ a:hover {
     left: 0;
     margin-bottom: 0;
     border-bottom: 1px solid white;
-    padding-bottom: .1em;
 }
 
 .navsettop a, .navsetbottom a {

--- a/scribble-lib/scribble/manual-style.css
+++ b/scribble-lib/scribble/manual-style.css
@@ -197,7 +197,7 @@ a:hover {
     top: 0;
     left: 0;
     margin-bottom: 0;
-    border-bottom: 0;
+    border-bottom: 1px solid white;
 }
 
 .navsettop a, .navsetbottom a {

--- a/scribble-lib/scribble/manual-style.css
+++ b/scribble-lib/scribble/manual-style.css
@@ -198,6 +198,7 @@ a:hover {
     left: 0;
     margin-bottom: 0;
     border-bottom: 1px solid white;
+    padding-bottom: .1em;
 }
 
 .navsettop a, .navsetbottom a {
@@ -442,6 +443,7 @@ a:hover {
 .tocview {
     text-align: left;
     background-color: inherit;
+    margin-top: 1em;
 }
 
 

--- a/scribble-lib/scribble/manual-style.css
+++ b/scribble-lib/scribble/manual-style.css
@@ -197,7 +197,7 @@ a:hover {
     top: 0;
     left: 0;
     margin-bottom: 0;
-    border-bottom: 1px solid white;
+    border-bottom: 0;
 }
 
 .navsettop a, .navsetbottom a {

--- a/scribble-lib/scribble/manual-style.css
+++ b/scribble-lib/scribble/manual-style.css
@@ -429,8 +429,7 @@ a:hover {
     width: 14rem;
     padding: 0rem 0.5rem 0.5rem 0.5rem;
     background-color: hsl(216, 15%, 70%);
-    margin: 6rem 0 0 0;
-
+    border-top: 6rem solid hsl(216, 15%, 70%);
 }
 
 .tocset td {

--- a/scribble-lib/scribble/manual-style.css
+++ b/scribble-lib/scribble/manual-style.css
@@ -394,15 +394,8 @@ a:hover {
     right: 2em;
     height: 0em;
     width: 13em;
-    margin: 0em 0em 0em -13em;
-}
-
-@media all and (max-width:1340px) {
-    /* avoid disappearing left note if display area is narrow */
-    .refparaleft, .refelemleft {
-        margin: 0em 0em 0em 0em;
-        right: 0em;
-     }
+    margin: 0em 0em 0em 0em;
+    display: contents;
 }
 
 .refcolumnleft {


### PR DESCRIPTION
This ensures that the scroll bar starts in the appropriate place, and the
background of the border is appropriate when the navtopset is missing

Fixes the issue @rfindler found in #297 after the merge.