### PR TITLE
Fix contracts on Secref and seclink

### DIFF
--- a/scribble-lib/scribble/base.rkt
+++ b/scribble-lib/scribble/base.rkt
@@ -568,13 +568,13 @@
                 #:link-render-style (or/c #f link-render-style?))
                element?)]
   [Secref (->* (string?)
-               (#:doc module-path?
+               (#:doc (or/c #f module-path?)
                 #:tag-prefixes (or/c #f (listof string?))
                 #:underline? any/c
                 #:link-render-style (or/c #f link-render-style?))
                element?)]
   [seclink (->* (string?)
-                (#:doc module-path?
+                (#:doc (or/c #f module-path?)
                  #:tag-prefixes (or/c #f (listof string?))
                  #:underline? any/c
                  #:indirect? any/c)


### PR DESCRIPTION
Both these functions allow the `#:doc` argument to be `#f`, and in fact that is the default value, but their contracts are overly strict, so passing it explicitly triggers a contract violation. This commit therefore weakens the contracts to allow `#f`, as they should.