### PR TITLE
Fix to match definition context hygiene change

### DIFF
--- a/scribble-text-lib/scribble/text/syntax-utils.rkt
+++ b/scribble-text-lib/scribble/text/syntax-utils.rkt
@@ -128,7 +128,7 @@
             [(def ids rhs)
              (datum->syntax expr*
                             (list #'def
-                                  (map syntax-local-identifier-as-binding
+                                  (map (lambda (id) (syntax-local-identifier-as-binding id (car ctx)))
                                        (syntax->list #'ids))
                                   #'rhs)
                             expr*


### PR DESCRIPTION
This should be merged when https://github.com/racket/racket/pull/3927 is.