### PR TITLE
add minimum version dependency to scribble-text-lib

### DIFF
--- a/scribble-text-lib/info.rkt
+++ b/scribble-text-lib/info.rkt
@@ -3,7 +3,8 @@
 (define collection 'multi)
 
 (define deps '("scheme-lib"
-               "base" "at-exp-lib"))
+               ["base" #:version "8.2.0.7"]
+               "at-exp-lib"))
 
 (define pkg-desc "Language for text with embedded Racket code")
 


### PR DESCRIPTION
The change in https://github.com/racket/scribble/commit/b149a17c3bb4fbfacd63e1c72d811a215741188c
depends on the expanded API of `syntax-local-identifier-as-binding` in https://github.com/racket/racket/commit/816c26482c414ed7a244bc25d0ba9749a6290e0b