### PR TITLE
Add table of contents toggle for low-width devices

### DIFF
--- a/scribble-lib/scribble/html-render.rkt
+++ b/scribble-lib/scribble/html-render.rkt
@@ -1017,6 +1017,15 @@
                   (url->string* (path->url up-path))
                   "../index.html")
          `[onclick . ,(format "return GotoPLTRoot(\"~a\");" (version))]))
+      (define tocset-toggle
+        (make-element
+         (make-style "tocsettoggle"
+                     (list
+                      (make-target-url "javascript:void(0);")
+                      (make-attributes
+                       '([title . "show/hide table of contents"]
+                         [onclick . "TocsetToggle();"]))))
+         "contents"))
       (define navleft
         `(span ([class "navleft"])
            ,@(if search-box?
@@ -1024,7 +1033,8 @@
                  (list `(div ([class "nosearchform"]))))
            ,@(render
               sep-element
-              (and up-path (make-element top-link top-content))
+              (and up-path (list (make-element top-link top-content) sep-element))
+              tocset-toggle
               ;; sep-element
               ;; (make-element
               ;;  (if parent (make-target-url "index.html" #f) "nonavigation")

--- a/scribble-lib/scribble/manual-style.css
+++ b/scribble-lib/scribble/manual-style.css
@@ -192,7 +192,7 @@ a:hover {
 
 .navsettop {
     position: fixed;
-    z-index: 1;
+    z-index: 2;
     background: #a7b0be;
     top: 0;
     left: 0;
@@ -234,7 +234,6 @@ a:hover {
 
 
 .navright {
-    height: 2rem;
     white-space: nowrap;
 }
 
@@ -414,6 +413,7 @@ a:hover {
 
 .tocset {
     position: fixed;
+    z-index: 2;
     overflow-y: scroll;
     float: none;
     left: 0;
@@ -701,12 +701,21 @@ blockquote > blockquote.SVInsetFlow {
         @media all and (max-width:520px){html {font-size: 10px;}}
 
         .navsettop, .navsetbottom {
-            display: block;
+            display: flex;
             position: absolute;
             width: 100%;
             height: 4rem;
             border: 0;
             background-color: hsl(216, 15%, 70%);
+            align-items: center;
+        }
+
+        .tocsetoverlay .navsettop {
+            position: fixed;
+        }
+
+        .navleft {
+            flex: 1;
         }
 
         .searchform {
@@ -714,10 +723,17 @@ blockquote > blockquote.SVInsetFlow {
             border: 0;
         }
 
+        .searchbox {
+            margin-top: 0;
+            margin-bottom: 0;
+        }
+
+        .navleft .tocsettoggle {
+            display: initial;
+        }
+
         .navright {
-            position: absolute;
-            right: 1.5rem;
-            margin-top: 1rem;
+            margin-right: 1.3rem;
             border: 0px solid red;
         }
 
@@ -728,24 +744,17 @@ blockquote > blockquote.SVInsetFlow {
 
         .tocset {
             display: none;
+            border-top-width: 4rem;
         }
 
-        .tocset table, .tocset tbody, .tocset tr, .tocset td {
-            display: inline;
-        }
-
-        .tocview {
-            display: none;
-        }
-
-        .tocsub .tocsubtitle {
-            display: none;
+        .tocsetoverlay .tocset {
+            display: block;
         }
 
         .versionbox {
             top: 4.5rem;
             left: 1rem; /* same distance as main-column */
-            z-index: 11000;
+            z-index: 1;
             height: 2em;
             font-size: 70%;
             font-weight: lighter;

--- a/scribble-lib/scribble/scribble-common.js
+++ b/scribble-lib/scribble/scribble-common.js
@@ -147,6 +147,10 @@ function TocviewToggle(glyph, id) {
   glyph.innerHTML = expand ? "&#9660;" : "&#9658;";
 }
 
+function TocsetToggle() {
+  document.body.classList.toggle("tocsetoverlay");
+}
+
 // Page Init ------------------------------------------------------------------
 
 // Note: could make a function that inspects and uses window.onload to chain to

--- a/scribble-lib/scribble/scribble.css
+++ b/scribble-lib/scribble/scribble.css
@@ -136,6 +136,10 @@ table td {
   color: #e0e0e0;
 }
 
+.navleft .tocsettoggle {
+  display: none;
+}
+
 .searchform {
   display: inline;
   margin: 0;


### PR DESCRIPTION
This adds a button to show / hide the TOC column on low-width devices.

It also adjusts various styles to keep the top bar fixed as you scroll so that the TOC toggle button remains accessible anywhere in the document. Flexbox is used in the low-width nav bars to improve vertical centering.

The appearance on high-width devices is unchanged. No TOC button is shown there.

https://user-images.githubusercontent.com/279572/132976575-bc61329e-c1fc-4cb1-a936-4fd9bbcd869d.mov

Fixes https://github.com/racket/scribble/issues/313
Also fixes https://github.com/racket/scribble/issues/305