### PR TITLE
Generate relative URLs for user docs index page

### DIFF
--- a/scribble-lib/scribble/html-render.rkt
+++ b/scribble-lib/scribble/html-render.rkt
@@ -2057,7 +2057,8 @@
 (define (explode p) (explode-path p))
 
 (define in-plt?
-  (let ([roots (map explode (filter values (list (find-doc-dir) (find-collects-dir))))])
+  ;; temporarily allow user docs to use relative paths
+  (let ([roots (map explode (filter values (list (find-doc-dir) (find-user-doc-dir) (find-user-pkgs-dir) (find-collects-dir))))])
     (lambda (path)
       (for/or ([root (in-list roots)])
         (let loop ([path  path] [root root])


### PR DESCRIPTION
This PR allows the html renderer to generate relative URLs for references of the installation-scope tags from the user-scope documents (in `(find-user-doc-dir)` and `(find-user-pkgs-dir)`). In particular, the index page of the user doc (`(find-user-doc-dir)/index.html`) will link to all packages using relative URLs.

I am not sure how to approach this problem differently.

- [ ] Make the relative path option configurable
- [ ] Documentation
- [ ] Check the layered-installations
- [ ] (Tests?)
