### PR TITLE
use \widebar from newtxmath

### DIFF
--- a/scribble-lib/scribble/scribble-load.tex
+++ b/scribble-lib/scribble/scribble-load.tex
@@ -19,7 +19,15 @@
 % acmart.cls is also using the one from newtxmath.
 \newcommand{\packageTxfonts}{
   \let\widering\relax
-  \usepackage{newtxmath}}
+  \let\oldwidebar\widebar
+  \let\widebar\relax
+  \usepackage{newtxmath}
+  % if newtxmath is before version 1.7.0,
+  % then we are still going to use widebar from mathabx
+  \ifx\widebar\relax
+    \let\widebar\oldwidebar
+  \fi
+}
 \newcommand{\packageTextcomp}{\usepackage{textcomp}}
 \newcommand{\packageFramed}{\usepackage{framed}}
 \newcommand{\packageHyphenat}{\usepackage[htt]{hyphenat}}


### PR DESCRIPTION
`newtxmath` has added `\widbar` since the version 1.7.0. The latest version of `newtxmath` is included in TeXLive 2022, which was just released in April.