### PR TITLE
Add kind information to the index

### DIFF
--- a/scribble-doc/scribblings/scribble/core.scrbl
+++ b/scribble-doc/scribblings/scribble/core.scrbl
@@ -1085,11 +1085,10 @@ The @racket[entry-seq] list must have the same length as
 final document.
 
 The @racket[desc] field provides additional information about the
-index entry as supplied by the entry creator. For example, a reference
-to a procedure binding can be recognized when @racket[desc] is an
-instance of @racket[procedure-index-desc]. See
-@racketmodname[scribble/manual-struct] for other typical types of
-@racket[desc] values.
+index entry as supplied by the entry creator. For example, a reference to
+a procedure binding can be recognized when @racket[desc] is an instance of
+@racket[exported-index-desc*] with the @racket['("procedure")] kind.
+See @racketmodname[scribble/manual-struct] for other types of @racket[desc] values.
 
 See also @racket[index].}
 

--- a/scribble-doc/scribblings/scribble/manual.scrbl
+++ b/scribble-doc/scribblings/scribble/manual.scrbl
@@ -2190,15 +2190,27 @@ exhaustive, because new modules can re-export the binding).}
 Indicates that the index entry corresponds to the definition of a
 syntactic form via @racket[defform] and company.}
 
+@defstruct[(form-index-desc* form-index-desc) ([kind string?])]{
+
+Like @racket[form-index-desc], but adds the kind information.}
+
 @defstruct[(procedure-index-desc exported-index-desc) ()]{
 
 Indicates that the index entry corresponds to the definition of a
 procedure binding via @racket[defproc] and company.}
 
+@defstruct[(procedure-index-desc* exported-index-desc) ([kind string?])]{
+
+Like @racket[procedure-index-desc], but adds the kind information.}
+
 @defstruct[(thing-index-desc exported-index-desc) ()]{
 
 Indicates that the index entry corresponds to the definition of a
 binding via @racket[defthing] and company.}
+
+@defstruct[(thing-index-desc* exported-index-desc) ([kind string?])]{
+
+Like @racket[thing-index-desc], but adds the kind information.}
 
 @defstruct[(struct-index-desc exported-index-desc) ()]{
 

--- a/scribble-doc/scribblings/scribble/manual.scrbl
+++ b/scribble-doc/scribblings/scribble/manual.scrbl
@@ -2185,55 +2185,74 @@ correspond to the documented name of the binding and the primary
 modules that export the documented name (but this list is not
 exhaustive, because new modules can re-export the binding).}
 
+@defstruct[(exported-index-desc* exported-index-desc) ([kind (listof (or/c string? (list/c 'code string?)))])]{
+
+Like @racket[exported-index-desc], but with the @racket[kind] information.
+Common values for @racket[kind] include:
+@racket['("procedure")], @racket['("syntax")], @racket['("value")].
+For the purpose of typesetting, the strings in @racket[kind] will be
+concatenated together, but those tagged with @racket['code]
+will be typeseted as code.
+
+The @racket[exported-index-desc*] struct is preferable over
+other index entry descriptions below.
+
+@history[#:added "1.46"]}
+
 @defstruct[(form-index-desc exported-index-desc) ()]{
+
+@deprecated[#:what "struct" @racket[exported-index-desc*]]
 
 Indicates that the index entry corresponds to the definition of a
 syntactic form via @racket[defform] and company.}
 
-@defstruct[(form-index-desc* form-index-desc) ([kind string?])]{
-
-Like @racket[form-index-desc], but adds the kind information.}
 
 @defstruct[(procedure-index-desc exported-index-desc) ()]{
+
+@deprecated[#:what "struct" @racket[exported-index-desc*]]
 
 Indicates that the index entry corresponds to the definition of a
 procedure binding via @racket[defproc] and company.}
 
-@defstruct[(procedure-index-desc* exported-index-desc) ([kind string?])]{
-
-Like @racket[procedure-index-desc], but adds the kind information.}
-
 @defstruct[(thing-index-desc exported-index-desc) ()]{
+
+@deprecated[#:what "struct" @racket[exported-index-desc*]]
 
 Indicates that the index entry corresponds to the definition of a
 binding via @racket[defthing] and company.}
 
-@defstruct[(thing-index-desc* exported-index-desc) ([kind string?])]{
-
-Like @racket[thing-index-desc], but adds the kind information.}
-
 @defstruct[(struct-index-desc exported-index-desc) ()]{
+
+@deprecated[#:what "struct" @racket[exported-index-desc*]]
 
 Indicates that the index entry corresponds to the definition of a
 structure type via @racket[defstruct] and company.}
 
 @defstruct[(class-index-desc exported-index-desc) ()]{
 
+@deprecated[#:what "struct" @racket[exported-index-desc*]]
+
 Indicates that the index entry corresponds to the definition of a
 class via @racket[defclass] and company.}
 
 @defstruct[(interface-index-desc exported-index-desc) ()]{
+
+@deprecated[#:what "struct" @racket[exported-index-desc*]]
 
 Indicates that the index entry corresponds to the definition of an
 interface via @racket[definterface] and company.}
 
 @defstruct[(mixin-index-desc exported-index-desc) ()]{
 
+@deprecated[#:what "struct" @racket[exported-index-desc*]]
+
 Indicates that the index entry corresponds to the definition of a
 mixin via @racket[defmixin] and company.}
 
 @defstruct[(method-index-desc exported-index-desc) ([method-name symbol?]
                                                     [class-tag tag?])]{
+
+@deprecated[#:what "struct" @racket[exported-index-desc*]]
 
 Indicates that the index entry corresponds to the definition of an
 method via @racket[defmethod] and company. The @racket[_name] field
@@ -2243,6 +2262,8 @@ The @racket[class-tag] field provides a pointer to the start of the
 documentation for the method's class or interface.}
 
 @defstruct[(constructor-index-desc exported-index-desc) ([class-tag tag?])]{
+
+@deprecated[#:what "struct" @racket[exported-index-desc*]]
 
 Indicates that the index entry corresponds to a constructor
 via @racket[defconstructor] and company. The @racket[_name] field

--- a/scribble-lib/info.rkt
+++ b/scribble-lib/info.rkt
@@ -23,7 +23,7 @@
 
 (define pkg-authors '(mflatt eli))
 
-(define version "1.45")
+(define version "1.46")
 
 (define license
   '(Apache-2.0 OR MIT))

--- a/scribble-lib/scribble/manual-struct.rkt
+++ b/scribble-lib/scribble/manual-struct.rkt
@@ -13,9 +13,12 @@
                                            [class-tag tag?])]
  [(constructor-index-desc exported-index-desc) ([class-tag tag?])]
  [(procedure-index-desc exported-index-desc) ()]
+ [(procedure-index-desc* procedure-index-desc) ([kind string?])]
  [(thing-index-desc exported-index-desc) ()]
+ [(thing-index-desc* thing-index-desc) ([kind string?])]
  [(struct-index-desc exported-index-desc) ()]
  [(form-index-desc exported-index-desc) ()]
+ [(form-index-desc* form-index-desc) ([kind string?])]
  [(class-index-desc exported-index-desc) ()]
  [(interface-index-desc exported-index-desc) ()]
  [(mixin-index-desc exported-index-desc) ()])

--- a/scribble-lib/scribble/manual-struct.rkt
+++ b/scribble-lib/scribble/manual-struct.rkt
@@ -3,22 +3,22 @@
          "private/provide-structs.rkt"
          racket/contract/base)
 
+(define kind/c (listof (or/c string? (list/c 'code string?))))
+
 (provide-structs
  [module-path-index-desc ()]
  [(language-index-desc module-path-index-desc) ()]
  [(reader-index-desc module-path-index-desc) ()]
  [exported-index-desc ([name symbol?]
                        [from-libs (listof module-path?)])]
+ [(exported-index-desc* exported-index-desc) ([kind kind/c])]
  [(method-index-desc exported-index-desc) ([method-name symbol?]
                                            [class-tag tag?])]
  [(constructor-index-desc exported-index-desc) ([class-tag tag?])]
  [(procedure-index-desc exported-index-desc) ()]
- [(procedure-index-desc* procedure-index-desc) ([kind string?])]
  [(thing-index-desc exported-index-desc) ()]
- [(thing-index-desc* thing-index-desc) ([kind string?])]
  [(struct-index-desc exported-index-desc) ()]
  [(form-index-desc exported-index-desc) ()]
- [(form-index-desc* form-index-desc) ([kind string?])]
  [(class-index-desc exported-index-desc) ()]
  [(interface-index-desc exported-index-desc) ()]
  [(mixin-index-desc exported-index-desc) ()])

--- a/scribble-lib/scribble/private/manual-bind.rkt
+++ b/scribble-lib/scribble/private/manual-bind.rkt
@@ -256,11 +256,12 @@
                                                  syntax-link-color
                                                  value-link-color)
                                              (list str)))))
-                                         ((if form?
-                                              make-form-index-desc
-                                              make-procedure-index-desc)
+                                         (make-exported-index-desc*
                                           id
-                                          (list mod-path)))))))))
+                                          (list mod-path)
+                                          (list (if form?
+                                                    "syntax"
+                                                    "procedure"))))))))))
       redirects))))
 
 

--- a/scribble-lib/scribble/private/manual-class.rkt
+++ b/scribble-lib/scribble/private/manual-class.rkt
@@ -188,7 +188,7 @@
           (flow-paragraphs
            (decode-flow (build-body decl post)))))))))))
 
-(define (*class-doc kind stx-id super all-intfs ranges whole-page? make-index-desc link?)
+(define (*class-doc kind stx-id super all-intfs ranges whole-page? link?)
   (define intfs (for/list ([intf (in-list all-intfs)])
                   (syntax-case intf ()
                     [(#:no-inherit intf) #'intf]
@@ -224,7 +224,10 @@
                                 (list ref-content)
                                 (with-exporting-libraries
                                  (lambda (libs)
-                                   (make-index-desc (syntax-e stx-id) libs)))))
+                                   (make-exported-index-desc*
+                                    (syntax-e stx-id)
+                                    libs
+                                    (list (symbol->string kind)))))))
                               tag)))
                           content))
                     (to-element stx-id))
@@ -315,7 +318,6 @@
                                        (list (quote-syntax intf) ...)
                                        null
                                        whole-page?
-                                       make-class-index-desc
                                        link?)))
                    (flatten-splices (list body ...))))
      link?)))
@@ -351,7 +353,6 @@
                                   (list (quote-syntax intf) ...)
                                   null
                                   whole-page?
-                                  make-interface-index-desc
                                   link?)))
                    (list body ...)))
      link?)))
@@ -380,7 +381,6 @@
                                   (list (quote-syntax domain) ...)
                                   (list (quote-syntax range) ...)
                                   whole-page?
-                                  make-mixin-index-desc
                                   link?)))
                    (list body ...)))
      link?)))

--- a/scribble-lib/scribble/private/manual-form.rkt
+++ b/scribble-lib/scribble/private/manual-form.rkt
@@ -299,7 +299,7 @@
 
 (define (meta-symbol? s) (memq s '(... ...+ ?)))
 
-(define (defform-site kw-id)
+(define (defform-site kw-id #:kind [kind "syntax"])
   (let ([target-maker (id-to-form-target-maker kw-id #t)])
     (define-values (content ref-content) (definition-site (syntax-e kw-id) kw-id #t))
     (if target-maker
@@ -315,14 +315,16 @@
                  (list ref-content)
                  (with-exporting-libraries
                   (lambda (libs)
-                    (make-form-index-desc (syntax-e kw-id)
-                                          libs))))
+                    (make-form-index-desc* (syntax-e kw-id)
+                                           libs
+                                           kind))))
                 content)
             tag
             ref-content)))
         content)))
 
 (define (*defforms kind link? kw-id forms form-procs subs sub-procs contract-procs content-thunk)
+  (define kind* (or kind "syntax"))
   (parameterize ([current-meta-list '(... ...+)])
     (make-box-splice
      (cons
@@ -336,7 +338,7 @@
                      [form-proc (in-list form-procs)]
                      [i (in-naturals)])
             (list
-             ((if (zero? i) (add-background-label (or kind "syntax")) values)
+             ((if (zero? i) (add-background-label kind*) values)
               (list
                ((or form-proc
                     (lambda (x)
@@ -345,7 +347,7 @@
                 (and kw-id
                      (if (eq? form (car forms))
                          (if link?
-                             (defform-site kw-id)
+                             (defform-site kw-id #:kind kind*)
                              (to-element #:defn? #t kw-id))
                          (to-element #:defn? #t kw-id))))))))
           (if (null? sub-procs)

--- a/scribble-lib/scribble/private/manual-form.rkt
+++ b/scribble-lib/scribble/private/manual-form.rkt
@@ -315,9 +315,9 @@
                  (list ref-content)
                  (with-exporting-libraries
                   (lambda (libs)
-                    (make-form-index-desc* (syntax-e kw-id)
-                                           libs
-                                           kind))))
+                    (make-exported-index-desc* (syntax-e kw-id)
+                                               libs
+                                               (list kind)))))
                 content)
             tag
             ref-content)))

--- a/scribble-lib/scribble/private/manual-proc.rkt
+++ b/scribble-lib/scribble/private/manual-proc.rkt
@@ -360,9 +360,10 @@
                                   content
                                   (with-exporting-libraries
                                    (lambda (libs)
-                                     (make-constructor-index-desc
+                                     (make-exported-index-desc*
                                       (syntax-e within-id)
-                                      libs ctag)))))
+                                      libs
+                                      (list (get-label)))))))
                            tag))))
                      (car content)))
                (car content)))
@@ -392,9 +393,11 @@
                                    (list ref-content)
                                    (with-exporting-libraries
                                     (lambda (libs)
-                                      (make-method-index-desc
-                                       (syntax-e within-id)
-                                       libs mname ctag)))))
+                                      (define sym (syntax-e within-id))
+                                      (make-exported-index-desc*
+                                       sym
+                                       libs
+                                       (list "method of " `(code ,(symbol->string sym))))))))
                             tag
                             ref-content))))
                       content))
@@ -415,7 +418,7 @@
                     (list ref-content)
                     (with-exporting-libraries
                      (lambda (libs)
-                       (make-procedure-index-desc* the-id libs (get-label)))))
+                       (make-exported-index-desc* the-id libs (list (get-label))))))
                    tag
                    ref-content)))
                content))]
@@ -1137,7 +1140,10 @@
                                       (list (datum-intern-literal (symbol->string name)))
                                       (list ref-content)
                                       (with-exporting-libraries
-                                        (lambda (libs) (make-thing-index-desc* name libs kind*))))
+                                        (lambda (libs) (make-exported-index-desc*
+                                                        name
+                                                        libs
+                                                        (list kind*)))))
                                      tag
                                      ref-content)))
                                  content))]
@@ -1215,9 +1221,12 @@
               (with-exporting-libraries
                (lambda (libs)
                  (let ([name (string->symbol name)])
-                   (if (eq? 'info (caar wrappers))
-                       (make-struct-index-desc name libs)
-                       (make-procedure-index-desc name libs))))))
+                   (make-exported-index-desc*
+                    name
+                    libs
+                    (list (if (eq? 'info (caar wrappers))
+                              "struct"
+                              "procedure")))))))
              tag)))
          content))
      (cdr wrappers))))

--- a/scribble-lib/scribble/private/manual-proc.rkt
+++ b/scribble-lib/scribble/private/manual-proc.rkt
@@ -415,7 +415,7 @@
                     (list ref-content)
                     (with-exporting-libraries
                      (lambda (libs)
-                       (make-procedure-index-desc the-id libs))))
+                       (make-procedure-index-desc* the-id libs (get-label)))))
                    tag
                    ref-content)))
                content))]
@@ -1084,6 +1084,7 @@
 (define (*defthing kind link? stx-ids names form? result-contracts content-thunk
                    [result-values (map (lambda (x) #f) result-contracts)])
   (define max-proto-width (current-display-width))
+  (define kind* (or kind "value"))
   (make-box-splice
    (cons
     (make-blockquote
@@ -1136,7 +1137,7 @@
                                       (list (datum-intern-literal (symbol->string name)))
                                       (list ref-content)
                                       (with-exporting-libraries
-                                       (lambda (libs) (make-thing-index-desc name libs))))
+                                        (lambda (libs) (make-thing-index-desc* name libs kind*))))
                                      tag
                                      ref-content)))
                                  content))]
@@ -1147,7 +1148,7 @@
             (append
              (list
               (list
-               ((if (zero? i) (add-background-label (or kind "value")) values)
+               ((if (zero? i) (add-background-label kind*) values)
                 (top-align
                  make-table-if-necessary
                  "argcontract"


### PR DESCRIPTION
This PR creates a new index description `exported-index-desc*` that contain the kind information.
This allows e.g. the search page to display or refine the query
based on the information.

To maintain backward compatibility, the kind information is not added to
any existing structs. Instead, a new index type is created.

The contract for the kind field is `(listof string? (list/c 'code string?))`.
This rich encoding allows typesetting search results like https://docs.racket-lang.org/search/index.html?q=get-admin

Also bump the version, to be used for `#:version` in other `info.rkt`

Original PR description is preserved here:

```
This PR creates new index types that contain the kind information.
This allows e.g. the search page to display or refine the query
based on the information.

Only `form-index-desc`, `procedure-index-desc`, and `thing-index-desc`
are considered, because they are the only ones that currently
allow kind customization. Other indices are already too specific
(e.g. `mixin`, `struct`), so there seems to be no point to allow
customization in such cases. On the other hand, newer forms
that need the kind customization probably should just use
`thing-index-desc(*)`, similar to how the Rhombus documentation
is currently doing.

To maintain backward compatability, the kind information is not added to
any existing structs. Instead, new index types are created at the leaf
level of the index description hierarchy.

It's unclear what the contract of the kind information should be.
Currently, it is `string?`. Here are some other possibilities

- `(or/c string? #f)`: this allows the information to be left out.
  However, I think that anything indexed with form, proc, or thing
  should mandate the kind information, because they default to
  "syntax", "procedure", or "value", so they are already non-empty.
  If one wishes to leave the information out, they can use
  `exported-index-desc` directly (this is what the `syntax/parse`
  library does).

- `xexpr?`: this allows richer encoding. In particular,
  `method-index-desc` currently displays information like
  "get-admin (method of editor<%>)" on the search page.
  This "(method of editor<%>)" is ad-hoc inserted and
  "editor%" is typeseted differently than "method of".
  The idea of `xexpr?` is to make it general enough to typeset
  "(method of editor<%>)" under one single framework,
  without special-casing `method-index-desc` and also allow
  this flexible customization for non-methods.

  On the other hand, allowing `xexpr?` could introduce vulnerabilities
  like HTML injection. We could constrain it, but that seems
  like too much work. So I think continuing to
  special-casing `method-index-desc` might be better.

Therefore, I'm sticking with `string?` for now, until we figure out a
better solution. However, it should be noted that further modification
will risk breaking backward compatibility.

Also bump the version, to be used for `#:version` in other `info.rkt`
```