### PR TITLE
search: handle URIError on decodeURIComponent

### DIFF
--- a/scribble-lib/scribble/scribble-common.js
+++ b/scribble-lib/scribble/scribble-common.js
@@ -19,7 +19,17 @@ var page_args =
 
 function GetPageArg(key, def) {
   for (var i=0; i<page_args.length; i++)
-    if (page_args[i][0] == key) return decodeURIComponent(page_args[i][1]);
+    if (page_args[i][0] === key) {
+      try {
+        return decodeURIComponent(page_args[i][1]);
+      } catch (e) {
+        if (e instanceof URIError) {
+          return page_args[i][1];
+        } else {
+          throw e;
+        }
+      }
+    }
   return def;
 }
 


### PR DESCRIPTION
Tools like Racket Mode could open a search page with an incorrectly encoded search query. While this is obviously the tools' fault, Scribble should be able to recover from the malformed input and not totally cease to function. This PR fixes the issue.