### PR TITLE
Add "white-space: pre" to RktIn

### DIFF
--- a/scribble-lib/scribble/manual-racket.css
+++ b/scribble-lib/scribble/manual-racket.css
@@ -60,6 +60,7 @@ span.RktValDef, span.RktStxDef, span.RktSymDef
 .RktIn {
   color: #cc6633;
   background-color: #eee;
+  white-space: pre;
 }
 
 .RktInBG {

--- a/scribble-lib/scribble/racket.css
+++ b/scribble-lib/scribble/racket.css
@@ -47,6 +47,7 @@
 .RktIn {
   color: #cc6633;
   background-color: #eeeeee;
+  white-space: pre;
 }
 
 .RktInBG {


### PR DESCRIPTION
Whitespaces should be preserved in `litchar`

Before the PR (on page https://docs.racket-lang.org/drracket/Keyboard_Shortcuts.html): 
<img width="79" alt="Screen Shot 2022-06-04 at 5 18 34 PM" src="https://user-images.githubusercontent.com/9099577/172029776-564edc96-18b3-4935-9a86-4bc2772c73b2.png">


After the PR:
<img width="80" alt="Screen Shot 2022-06-04 at 5 18 44 PM" src="https://user-images.githubusercontent.com/9099577/172029760-0f2b92e0-f65a-4c9e-8f6d-3748db0fe502.png">

