### PR TITLE
scribble/text-render: support `(linebreak)`

### DIFF
--- a/scribble-test/tests/scribble/docs/linebreak.scrbl
+++ b/scribble-test/tests/scribble/docs/linebreak.scrbl
@@ -1,0 +1,18 @@
+#lang scribble/base
+
+So oft have I invoked thee for my Muse @(linebreak)
+And found such fair assistance in my verse @linebreak[]
+As every alien pen hath got my use @(linebreak)
+And under thee their poesy disperse.
+
+Thine eyes, that taught the dumb on high to sing @linebreak[]
+And heavy ignorance aloft to fly, @linebreak[]
+Have added feathers to the learnèd's wing @linebreak[] And given grace a double majesty.
+
+Yet be most proud of that which I compile, @linebreak[] Whose influence is thine
+and born of thee. @linebreak[] In others' works thou dost
+but mend the style, @linebreak[]
+And arts with thy sweet graces gracèd be;
+
+But thou art all my art, and dost advance @linebreak[]
+As high learning my rude ignorance.

--- a/scribble-test/tests/scribble/docs/linebreak.txt
+++ b/scribble-test/tests/scribble/docs/linebreak.txt
@@ -1,0 +1,17 @@
+So oft have I invoked thee for my Muse
+And found such fair assistance in my verse
+As every alien pen hath got my use
+And under thee their poesy disperse.
+
+Thine eyes, that taught the dumb on high to sing
+And heavy ignorance aloft to fly,
+Have added feathers to the learnèd’s wing
+And given grace a double majesty.
+
+Yet be most proud of that which I compile,
+Whose influence is thine and born of thee.
+In others’ works thou dost but mend the style,
+And arts with thy sweet graces gracèd be;
+
+But thou art all my art, and dost advance
+As high learning my rude ignorance.


### PR DESCRIPTION
Here's an attempt at an implementation, tested so far only on my current draft of https://github.com/racket/racket/pull/4301.

Related to https://github.com/racket/racket/pull/4301
Closes https://github.com/racket/scribble/issues/333