### PR TITLE
Analyze pull requests with Resyntax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,20 +16,17 @@ jobs:
           distribution: full
           variant: ${{ matrix.racket-variant }}
           version: current
+          dest: '"${HOME}/racketdist-${{ matrix.racket-variant }}"'
+          local_catalogs: $GITHUB_WORKSPACE
+          sudo: never
 
-      # This next step was copied from the CI config for Typed Racket:
-      # https://github.com/racket/typed-racket/blob/master/.github/workflows/ci.yml
       - run: |
-             sudo raco pkg install --auto -i --no-setup --skip-installed scribble-test
-             racket -l- pkg/dirs-catalog --link --check-metadata pkgs-catalog .
-             echo file://`pwd`/pkgs-catalog/ > catalog-config.txt
-             raco pkg config catalogs >> catalog-config.txt
-             sudo raco pkg config --set catalogs `cat catalog-config.txt`
-             sudo raco pkg update -i --auto --no-setup scribble-text-lib/ scribble-html-lib/ scribble-lib/ scribble-doc/ scribble-test/
+          raco pkg install -i --auto --no-setup --skip-installed scribble-test
+          raco pkg update --auto --no-setup scribble-text-lib scribble-html-lib scribble-lib scribble-doc scribble-test
 
       # This uses --pkgs so that we don't have to figure out which collections
       # each package adds modules to.
-      - run: sudo raco setup --check-pkg-deps --pkgs scribble-text-lib scribble-html-lib scribble-lib scribble-doc scribble-test
+      - run: raco setup --check-pkg-deps --pkgs scribble-text-lib scribble-html-lib scribble-lib scribble-doc scribble-test
 
       # Tests are run with --drdr to help keep racket's CI systems consistent
       # with each other.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
         racket-variant: ["BC", "CS"]
     steps:
       - uses: actions/checkout@master
-      - uses: Bogdanp/setup-racket@v0.13
+      - uses: Bogdanp/setup-racket@v1.8.1
         with:
           architecture: x64
           distribution: full

--- a/.github/workflows/resyntax.yml
+++ b/.github/workflows/resyntax.yml
@@ -1,0 +1,35 @@
+name: Resyntax
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - ready_for_review
+
+jobs:
+  build:
+    name: Analyze pull request
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v2
+        # See https://github.com/actions/checkout/issues/118.
+        with:
+          fetch-depth: 0
+      - uses: Bogdanp/setup-racket@v1.8.1
+        with:
+          version: current
+          packages: resyntax
+          local_catalogs: $GITHUB_WORKSPACE
+          dest: '"${HOME}/racketdist-current-CS"'
+          sudo: never
+      - run: |
+          raco pkg install -i --auto --no-setup --skip-installed scribble-test
+          raco pkg update --auto --no-setup scribble-text-lib scribble-html-lib scribble-lib scribble-doc scribble-test
+      - run: raco setup --pkgs scribble-text-lib scribble-html-lib scribble-lib scribble-doc scribble-test
+      - run: xvfb-run racket -l- resyntax/cli analyze --local-git-repository . "origin/${GITHUB_BASE_REF}" --output-as-github-review


### PR DESCRIPTION
This is a similar pull request to racket/typed-racket#1250. @mflatt suggested the Scribble repository as another good project to try Resyntax on, since it's old, large, and frequently receives pull requests. See the typed racket pull request for details about what this change does. TL;DR: it runs Resyntax over pull requests and leaves github reviews with suggested improvements.