### PR TITLE
add `#:indirect?` argument for `tech` and `techlink`

### DIFF
--- a/scribble-doc/scribblings/scribble/core.scrbl
+++ b/scribble-doc/scribblings/scribble/core.scrbl
@@ -1057,7 +1057,13 @@ properties for all @racket[element]s:
        provide an external-link URL, then the resolution of the
        hyperlink can be deferred until the link is clicked (or, in
        some cases, patched by JavaScript when the documentation is
-       viewed in a browser).}
+       viewed in a browser).
+
+       Note that deferred resolution relies on cooperation with the page
+       pointed to by the external-link URL, and arbitrary tags are not supported.
+       Functions and forms like @racket[seclink], @racket[other-doc],
+       @racket[racketmodname], @racket[tech], and @racket[techlink] provide
+       higher-level interfaces for creating supported kinds of indirect links.}
 
 ]
 

--- a/scribble-doc/scribblings/scribble/manual.scrbl
+++ b/scribble-doc/scribblings/scribble/manual.scrbl
@@ -1871,7 +1871,8 @@ If @racket[style?] is true, then @racket[defterm] is used on
                [#:key key (or/c string? #f) #f]
                [#:normalize? normalize? any/c #t]
                [#:doc module-path (or/c module-path? #f) #f]
-               [#:tag-prefixes prefixes (or/c (listof string?) #f) #f])
+               [#:tag-prefixes prefixes (or/c (listof string?) #f) #f]
+               [#:indirect? indirect? any/c #f])
          element?]{
 
 Produces an element for the @tech{decode}d @racket[pre-content], and
@@ -1887,6 +1888,8 @@ For example:
 
 creates a link to @tech[#:doc '(lib "scribblings/reference/reference.scrbl")]{blame object} in
 @other-doc['(lib "scribblings/reference/reference.scrbl")].
+If @racket[indirect?] is not @racket[#f], the link’s resolution in HTML
+is potentially delayed; see @racket['indirect-link] for @racket[link-element].
 
 With the default style files, the hyperlink created by @racket[tech]
 is somewhat quieter than most hyperlinks: the underline in HTML output
@@ -1897,18 +1900,27 @@ In some cases, combining both natural-language uses of a term and
 proper linking can require some creativity, even with the
 normalization performed on the term. For example, if ``bind'' is
 defined, but a sentence uses the term ``binding,'' the latter can be
-linked to the former using @racketfont["@tech{bind}ing"].}
+linked to the former using @racketfont["@tech{bind}ing"].
+
+ @history[
+ #:changed "1.46" @elem{Added @racket[#:indirect?] argument.}
+ ]}
 
 @defproc[(techlink [pre-content pre-content?] ...
                    [#:key key (or/c string? #f) #f]
                    [#:normalize? normalize? any/c #t]
                    [#:doc module-path (or/c module-path? #f) #f]
-                   [#:tag-prefixes prefixes (or/c (listof string?) #f) #f]) 
+                   [#:tag-prefixes prefixes (or/c (listof string?) #f) #f]
+                   [#:indirect? indirect? any/c #f])
          element?]{
 
 Like @racket[tech], but the link is not quiet. For example, in HTML
 output, a hyperlink underline appears even when the mouse is not over
-the link.}
+the link.
+
+ @history[
+ #:changed "1.46" @elem{Added @racket[#:indirect?] argument.}
+ ]}
 
 @; ------------------------------------------------------------------------
 @section[#:tag "manual-indexing"]{Indexing}

--- a/scribble-lib/info.rkt
+++ b/scribble-lib/info.rkt
@@ -23,7 +23,7 @@
 
 (define pkg-authors '(mflatt eli))
 
-(define version "1.45")
+(define version "1.46")
 
 (define license
   '((Apache-2.0 OR MIT)

--- a/scribble-lib/scribble/private/manual-tech.rkt
+++ b/scribble-lib/scribble/private/manual-tech.rkt
@@ -2,6 +2,7 @@
 (require racket/contract/base
          "../decode.rkt"
          "../struct.rkt"
+         (only-in "../core.rkt" style)
          "manual-utils.rkt"
          "manual-style.rkt")
 
@@ -14,14 +15,16 @@
         (#:doc (or/c module-path? #f) 
          #:tag-prefixes (or/c (listof string?) #f) 
          #:key (or/c string? #f)
-         #:normalize? any/c)
+         #:normalize? any/c
+         #:indirect? any/c)
         #:rest (listof pre-content?) 
         . ->* . element?)]
  [techlink (() 
             (#:doc (or/c module-path? #f) 
              #:tag-prefixes (or/c (listof string?) #f) 
              #:key (or/c string? #f)
-             #:normalize? any/c)
+             #:normalize? any/c
+             #:indirect? any/c)
             #:rest (listof pre-content?) 
             . ->* . element?)])
 
@@ -54,14 +57,17 @@
                         (list e)
                         'tech)))
 
-(define (tech #:doc [doc #f] 
-              #:tag-prefixes [prefix #f] 
-              #:key [key #f] 
-              #:normalize? [normalize? #t] 
+(define (tech #:doc [doc #f]
+              #:tag-prefixes [prefix #f]
+              #:key [key #f]
+              #:normalize? [normalize? #t]
+              #:indirect? [indirect? #f]
               . s)
-  (*tech (lambda (style c tag)
+  (*tech (lambda (sty c tag)
            (make-link-element
-            style
+            (if indirect?
+                (style sty '(indirect-link))
+                sty)
             (list (make-element "techinside" c))
             tag))
          "techoutside"
@@ -71,6 +77,16 @@
 (define (techlink #:doc [doc #f] 
                   #:tag-prefixes [prefix #f] 
                   #:key [key #f] 
-                  #:normalize? [normalize? #t] 
+                  #:normalize? [normalize? #t]
+                  #:indirect? [indirect? #t]
                   . s)
-  (*tech make-link-element #f doc prefix s key normalize?))
+  (*tech (lambda (sty c tag)
+           (make-link-element
+            (if indirect?
+                (style sty '(indirect-link))
+                sty)
+            c
+            tag))
+         #f
+         doc prefix s key
+         normalize?))


### PR DESCRIPTION
These seem to do the right thing, but the links they generate for https://github.com/racket/racket/pull/4301 don't redirect successfully, and I don't understand why. So, this probably isn't ready to merge yet.