### PR TITLE
Actually use link-render-style in Secref

### DIFF
--- a/scribble-lib/scribble/base.rkt
+++ b/scribble-lib/scribble/base.rkt
@@ -600,9 +600,13 @@
                      (make-section-tag s #:doc doc #:tag-prefixes prefix)))
 (define (Secref s #:underline? [u? #t] #:doc [doc #f] #:tag-prefixes [prefix #f]
                 #:link-render-style [link-style #f])
-  (let ([le (secref s #:underline? u? #:doc doc #:tag-prefixes prefix)])
+  (let ([le (secref s #:underline? u? #:doc doc #:tag-prefixes prefix
+                    #:link-render-style link-style)])
     (make-link-element
-     (make-style (element-style le) '(uppercase))
+     (style (style-name (element-style le))
+            (cons 'uppercase (if link-style
+                                 (list link-style)
+                                 '())))
      (element-content le)
      (link-element-tag le))))
 


### PR DESCRIPTION
I tried to rebuild the style from the style of `le` as was done previously, but this ran into contract errors that seem to suggest the contract is wrong, so I did this instead.

Is the contract on `make-style` actually accounting for this style property?

closes #348 