### PR TITLE
Add constraints that descriptions must be non-keyword

### DIFF
--- a/scribble-lib/scribble/private/manual-form.rkt
+++ b/scribble-lib/scribble/private/manual-form.rkt
@@ -241,10 +241,11 @@
 
 (define-syntax (specsubform/subs stx)
   (syntax-parse stx
-    [(_ l:literals-kw spec g:grammar desc:expr ...)
+    [(_ l:literals-kw spec g:grammar c:contracts-kw desc:expr ...)
      (syntax/loc stx
        (spec?form/subs #f #:literals (l.lit ...) spec 
-                       ([g.non-term-id g.non-term-form ...] ...) 
+                       ([g.non-term-id g.non-term-form ...] ...)
+                       #:contracts c.cs
                        desc ...))]))
 
 (define-syntax-rule (specspecsubform spec desc ...)
@@ -261,10 +262,11 @@
 
 (define-syntax (specform/subs stx)
   (syntax-parse stx
-    [(_ l:literals-kw spec g:grammar
+    [(_ l:literals-kw spec g:grammar c:contracts-kw
         desc:expr ...)
      (syntax/loc stx
        (spec?form/subs #t #:literals (l.lit ...) spec ([g.non-term-id g.non-term-form ...] ...)
+                       #:contracts c.cs
                        desc ...))]))
 
 (define-syntax-rule (specsubform/inline spec desc ...)

--- a/scribble-lib/scribble/private/manual-form.rkt
+++ b/scribble-lib/scribble/private/manual-form.rkt
@@ -143,13 +143,13 @@
 
 (define-syntax (defform/subs stx)
   (syntax-parse stx
-    [(_ k:kind-kw lt:link-target?-kw d:id-kw l:literals-kw spec subs desc:expr ...)
+    [(_ k:kind-kw lt:link-target?-kw d:id-kw l:literals-kw spec subs c:contracts-kw desc:expr ...)
      (syntax/loc stx
        (defform*/subs #:kind k.kind 
          #:link-target? lt.expr
          #:id [d.defined-id d.defined-id-expr] 
          #:literals (l.lit ...)
-         [spec] subs desc ...))]))
+         [spec] subs #:contracts c.cs desc ...))]))
 
 (define-syntax (defform/none stx)
   (syntax-parse stx

--- a/scribble-lib/scribble/private/manual-form.rkt
+++ b/scribble-lib/scribble/private/manual-form.rkt
@@ -81,7 +81,7 @@
     [(_ k:kind-kw lt:link-target?-kw d:id-kw l:literals-kw [spec spec1 ...]
         g:grammar
         c:contracts-kw
-        desc ...)
+        desc:expr ...)
      (with-syntax* ([defined-id (if (syntax-e #'d.defined-id)
                                     #'d.defined-id
                                     (syntax-case #'spec ()
@@ -122,7 +122,7 @@
 (define-syntax (defform* stx)
   (syntax-parse stx
     [(_ k:kind-kw lt:link-target?-kw d:id-kw l:literals-kw [spec ...+]
-        subs:subs-kw c:contracts-kw desc ...)
+        subs:subs-kw c:contracts-kw desc:expr ...)
      (syntax/loc stx
        (defform*/subs #:kind k.kind 
          #:link-target? lt.expr
@@ -133,7 +133,7 @@
 (define-syntax (defform stx)
   (syntax-parse stx
     [(_ k:kind-kw lt:link-target?-kw d:id-kw l:literals-kw spec
-        subs:subs-kw c:contracts-kw desc ...)
+        subs:subs-kw c:contracts-kw desc:expr ...)
      (syntax/loc stx
        (defform*/subs #:kind k.kind
          #:link-target? lt.expr
@@ -143,7 +143,7 @@
 
 (define-syntax (defform/subs stx)
   (syntax-parse stx
-    [(_ k:kind-kw lt:link-target?-kw d:id-kw l:literals-kw spec subs desc ...)
+    [(_ k:kind-kw lt:link-target?-kw d:id-kw l:literals-kw spec subs desc:expr ...)
      (syntax/loc stx
        (defform*/subs #:kind k.kind 
          #:link-target? lt.expr
@@ -153,7 +153,7 @@
 
 (define-syntax (defform/none stx)
   (syntax-parse stx
-    [(_ k:kind-kw lt:link-target?-kw l:literals-kw spec subs:subs-kw c:contracts-kw desc ...)
+    [(_ k:kind-kw lt:link-target?-kw l:literals-kw spec subs:subs-kw c:contracts-kw desc:expr ...)
      (syntax/loc stx
        (with-togetherable-racket-variables
         (l.lit ...)
@@ -182,7 +182,7 @@
 
 (define-syntax (defidform stx)
   (syntax-parse stx
-    [(_ k:kind-kw lt:link-target?-kw spec-id desc ...)
+    [(_ k:kind-kw lt:link-target?-kw spec-id desc:expr ...)
      #'(with-togetherable-racket-variables
         ()
         ()
@@ -216,7 +216,7 @@
   (syntax-parse stx
     [(_ has-kw? l:literals-kw spec g:grammar
         c:contracts-kw
-        desc ...)
+        desc:expr ...)
      (syntax/loc stx
        (with-racket-variables
         (l.lit ...)
@@ -235,13 +235,13 @@
 
 (define-syntax (specsubform stx)
   (syntax-parse stx
-    [(_ l:literals-kw spec subs:subs-kw c:contracts-kw desc ...)
+    [(_ l:literals-kw spec subs:subs-kw c:contracts-kw desc:expr ...)
      (syntax/loc stx
        (spec?form/subs #f #:literals (l.lit ...) spec subs.g #:contracts c.cs desc ...))]))
 
 (define-syntax (specsubform/subs stx)
   (syntax-parse stx
-    [(_ l:literals-kw spec g:grammar desc ...)
+    [(_ l:literals-kw spec g:grammar desc:expr ...)
      (syntax/loc stx
        (spec?form/subs #f #:literals (l.lit ...) spec 
                        ([g.non-term-id g.non-term-form ...] ...) 
@@ -262,7 +262,7 @@
 (define-syntax (specform/subs stx)
   (syntax-parse stx
     [(_ l:literals-kw spec g:grammar
-        desc ...)
+        desc:expr ...)
      (syntax/loc stx
        (spec?form/subs #t #:literals (l.lit ...) spec ([g.non-term-id g.non-term-form ...] ...)
                        desc ...))]))

--- a/scribble-lib/scribble/private/manual-proc.rkt
+++ b/scribble-lib/scribble/private/manual-proc.rkt
@@ -176,7 +176,7 @@
         (id arg ...)
         result
         value:value-kw
-        desc ...)
+        desc:expr ...)
      (syntax/loc stx
        (defproc*
          #:kind kind.kind
@@ -193,7 +193,7 @@
         mode:mode-kw
         within:within-kw
         [[proto result value:value-kw] ...+]
-        desc ...)
+        desc:expr ...)
      (syntax/loc stx
        (with-togetherable-racket-variables
         ()
@@ -650,19 +650,19 @@
 
 (define-syntax (defparam stx)
   (syntax-parse stx
-    [(_ lt:link-target?-kw id arg contract value:value-kw desc ...)
+    [(_ lt:link-target?-kw id arg contract value:value-kw desc:expr ...)
      #'(defproc* #:kind "parameter" #:link-target? lt.expr
          ([(id) contract] [(id [arg contract]) void? #:value value.value]) 
          desc ...)]))
 (define-syntax (defparam* stx)
   (syntax-parse stx
-    [(_ lt:link-target?-kw id arg in-contract out-contract value:value-kw desc ...)
+    [(_ lt:link-target?-kw id arg in-contract out-contract value:value-kw desc:expr ...)
      #'(defproc* #:kind "parameter" #:link-target? lt.expr
          ([(id) out-contract] [(id [arg in-contract]) void? #:value value.value])
          desc ...)]))
 (define-syntax (defboolparam stx)
   (syntax-parse stx
-    [(_ lt:link-target?-kw id arg value:value-kw desc ...)
+    [(_ lt:link-target?-kw id arg value:value-kw desc:expr ...)
      #'(defproc* #:kind "parameter" #:link-target? lt.expr
          ([(id) boolean?] [(id [arg any/c]) void? #:value value.value])
          desc ...)]))
@@ -733,7 +733,7 @@
      (syntax-parse stx
        [(_ lt:link-target?-kw name fields 
            m:mutable-kw o:opacity-kw c:constructor-kw 
-           desc ...)
+           desc:expr ...)
         #`(**defstruct lt.expr name fields 
                        m.immutable? o.opacity
                        c.id c.given? c.extra? default-extra? c.omit?
@@ -1056,7 +1056,7 @@
         id 
         result 
         value:value-kw
-        desc ...)
+        desc:expr ...)
      #'(with-togetherable-racket-variables
         ()
         ()
@@ -1070,7 +1070,7 @@
 
 (define-syntax (defthing* stx)
   (syntax-parse stx
-    [(_ kind:kind-kw lt:link-target?-kw ([id result value:value-kw] ...+) desc ...)
+    [(_ kind:kind-kw lt:link-target?-kw ([id result value:value-kw] ...+) desc:expr ...)
      #'(with-togetherable-racket-variables
         ()
         ()


### PR DESCRIPTION
The following program:

```
@defform[(stream elem-expr ...)
         #:literals (values)
         #:grammar ([elem-expr (values single-expr ...)
                               single-expr])]{
  Description ...
}
```

is faulty because `#:literals (values)` is misplaced. It should come before `(stream elem-expr ...)`.
However, the error that occurs is very confusing.

elem-expr: misuse of an identifier (not in `racket', etc.) that is bound as a code-typesetting variable

When parsing the form, `#:literals ... #:grammar ...` becomes a part of the description because there is no constraint that the description must not be keywords.
The resulting expansion is `(list #:literals .... #:grammar <grammar> ....)`, which happens to be valid, though `<grammar>` is not meant to be an expression. This is the cause of the mentioned confusing error message.

This PR adds the constraint that desc must be non-keyword, so that the above program errors appropriately on parsing.