### PR TITLE
tex-table: add guillemetleft and guillemetright

### DIFF
--- a/scribble-lib/scribble/latex-render.rkt
+++ b/scribble-lib/scribble/latex-render.rkt
@@ -1530,6 +1530,8 @@
         [(#\ℜ) "$\\mathfrak{R}$"]
         [(#\ℨ) "$\\mathfrak{Z}$"]
         [(#\ℭ) "$\\mathfrak{C}$"]
+        [(#\«) "\\guillemetleft"]
+        [(#\») "\\guillemetright"]
         [else #f]))
 
     ;; ----------------------------------------

--- a/scribble-lib/scribble/latex-render.rkt
+++ b/scribble-lib/scribble/latex-render.rkt
@@ -1530,8 +1530,8 @@
         [(#\ℜ) "$\\mathfrak{R}$"]
         [(#\ℨ) "$\\mathfrak{Z}$"]
         [(#\ℭ) "$\\mathfrak{C}$"]
-        [(#\«) "\\guillemetleft"]
-        [(#\») "\\guillemetright"]
+        [(#\«) "\\guillemotleft"]  ; the correct spelling is guillemet,
+        [(#\») "\\guillemotright"] ; but guillemot works in older LaTeX versions
         [else #f]))
 
     ;; ----------------------------------------


### PR DESCRIPTION
guillemetleft for `«`, and guillemetright for `»`.

See also https://github.com/racket/gui/pull/297