### PR TITLE
Update the workflow to account for CI failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
         racket-variant: ["BC", "CS"]
     steps:
       - uses: actions/checkout@master
-      - uses: Bogdanp/setup-racket@v0.13
+      - uses: Bogdanp/setup-racket@v1.10
         with:
           architecture: x64
           distribution: full

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,26 +10,23 @@ jobs:
         racket-variant: ["BC", "CS"]
     steps:
       - uses: actions/checkout@master
+      # The next two step was copied from the CI config for Typed Racket:
+      # https://github.com/racket/typed-racket/blob/master/.github/workflows/ci.yml
       - uses: Bogdanp/setup-racket@v1.10
         with:
           architecture: x64
           distribution: full
           variant: ${{ matrix.racket-variant }}
           version: current
+          dest: '"${HOME}/racketdist-${{ matrix.racket-variant }}"'
+          local_catalogs: $GITHUB_WORKSPACE
+          sudo: never
 
-      # This next step was copied from the CI config for Typed Racket:
-      # https://github.com/racket/typed-racket/blob/master/.github/workflows/ci.yml
-      - run: |
-             sudo raco pkg install --auto -i --no-setup --skip-installed scribble-test
-             racket -l- pkg/dirs-catalog --link --check-metadata pkgs-catalog .
-             echo file://`pwd`/pkgs-catalog/ > catalog-config.txt
-             raco pkg config catalogs >> catalog-config.txt
-             sudo raco pkg config --set catalogs `cat catalog-config.txt`
-             sudo raco pkg update -i --auto --no-setup scribble-text-lib/ scribble-html-lib/ scribble-lib/ scribble-doc/ scribble-test/
-
+      - run: raco pkg update -i --no-setup scribble-text-lib scribble-html-lib scribble-lib scribble-doc scribble
+      - run: raco pkg install --auto -i --no-setup --skip-installed scribble-test
       # This uses --pkgs so that we don't have to figure out which collections
       # each package adds modules to.
-      - run: sudo raco setup --check-pkg-deps --pkgs scribble-text-lib scribble-html-lib scribble-lib scribble-doc scribble-test
+      - run: raco setup --check-pkg-deps --pkgs scribble-text-lib scribble-html-lib scribble-lib scribble-doc scribble-test
 
       # Tests are run with --drdr to help keep racket's CI systems consistent
       # with each other.


### PR DESCRIPTION
- Bump the version of `Bogdanp/setup-racket` to fix the CI failure
- Modernize local catalog setup in the workflow using the `local_catalogs:` feature introduced in setup-racket v1.2