### PR TITLE
feat: support #:auto-value for defparam and defthing

### DIFF
--- a/scribble-doc/scribblings/scribble/manual.scrbl
+++ b/scribble-doc/scribblings/scribble/manual.scrbl
@@ -2,6 +2,7 @@
 @(require scribble/manual "utils.rkt"
           (for-syntax racket/base)
           (for-label scribble/manual-struct
+                     racket/list
                      version/utils
                      syntax/quote))
 
@@ -1308,7 +1309,7 @@ Examples:
 
 @defform[(defparam maybe-link id arg-id
            contract-expr-datum
-           maybe-value
+           maybe-auto-value
            pre-flow ...)]{
 
 Like @racket[defproc], but for a parameter. The
@@ -1324,19 +1325,30 @@ Examples:
   A parameter that defines the current sandwich for operations that
   involve eating a sandwich. Default value is the empty sandwich.
 }
+
+@(require (for-label racket/base))
+
+@defparam[current-readtable v any/c #:auto-value]{
+  A parameter to hold a readtable.
+}
 }|
 @doc-render-examples[
   @defparam[#:link-target? #f
             current-sandwich sandwich sandwich? #:value empty-sandwich]{
     A parameter that defines the current sandwich for operations that
     involve eating a sandwich. Default value is the empty sandwich.
-  }]
+  }
+  @defparam[#:link-target? #f
+            current-readtable v any/c #:auto-value]{
+    A parameter to hold a readtable.
+  }
+]
 }
 
 
 @defform[(defparam* maybe-link id arg-id 
            in-contract-expr-datum out-contract-expr-datum
-           maybe-value
+           maybe-auto-value
            pre-flow ...)]{
 
 Like @racket[defparam], but with separate contracts for when the parameter is being
@@ -1346,7 +1358,7 @@ coerces values matching a more flexible contract to a more restrictive one;
 
 
 @defform[(defboolparam maybe-link id arg-id
-           maybe-value
+           maybe-auto-value
            pre-flow ...)]{
 
 Like @racket[defparam], but the contract on a parameter argument is
@@ -1354,7 +1366,7 @@ Like @racket[defparam], but the contract on a parameter argument is
 @racket[boolean?].}
 
 
-@defform/subs[(defthing options id contract-expr-datum maybe-value
+@defform/subs[(defthing options id contract-expr-datum maybe-auto-value
                 pre-flow ...)
               ([options (code:line maybe-kind maybe-link maybe-id)]
                [maybe-kind code:blank
@@ -1363,8 +1375,9 @@ Like @racket[defparam], but the contract on a parameter argument is
                            (code:line #:link-target? link-target?-expr)]
                [maybe-id code:blank
                          (code:line #:id id-expr)]
-               [maybe-value code:blank
-                            (code:line #:value value-expr-datum)])]{
+               [maybe-auto-value code:blank
+                            (code:line #:value value-expr-datum)
+                            #:auto-value])]{
 
 Like @racket[defproc], but for a non-procedure binding.
 
@@ -1379,6 +1392,11 @@ If @racket[#:value value-expr-datum] is given, @racket[value-expr-datum]
 is typeset using @racket[racketblock0] and included in the documentation.
 Wide values are put on a separate line.
 
+The option @racket[#:auto-value] is the same as @racket[#:value value-expr-datum]
+where @racket[value-expr-datum] is automatically queried from the for-label binding.
+@racket[#:auto-value] can only be used when the value is marshalable
+(e.g., if the value is a struct, it must be a prefab struct of marshalable values).
+
 Examples:
 @codeblock[#:keep-lang-line? #f]|{
 #lang scribble/manual
@@ -1389,6 +1407,12 @@ Examples:
 @defthing[empty-sandwich sandwich? #:value (make-sandwich empty)]{
   The empty sandwich.
 }
+
+@(require (for-label racket/list))
+
+@defthing[empty any/c #:auto-value]{
+  The empty list.
+}
 }|
 @doc-render-examples[
   @defthing[#:link-target? #f
@@ -1398,10 +1422,15 @@ Examples:
   @defthing[#:link-target? #f
             empty-sandwich sandwich? #:value (make-sandwich empty)]{
     The empty sandwich.
-  }]
+  }
+  @defthing[#:link-target? #f
+            empty any/c #:auto-value]{
+    The empty list.
+  }
+]
 }
 
-@defform[(defthing* options ([id contract-expr-datum maybe-value] ...+)
+@defform[(defthing* options ([id contract-expr-datum maybe-auto-value] ...+)
            pre-flow ...)]{
 
 Like @racket[defthing], but for multiple non-procedure bindings.

--- a/scribble-lib/scribble/private/marshal.rkt
+++ b/scribble-lib/scribble/private/marshal.rkt
@@ -1,0 +1,15 @@
+#lang racket/base
+
+(provide check-marshalable)
+
+(require racket/fasl
+         racket/match)
+
+;; check-marshalable : any/c -> (or/c #f any/c)
+(define (check-marshalable v)
+  (match (call/cc (λ (return)
+                    (s-exp->fasl
+                     v
+                     #:handle-fail (λ (v) (return `(failed ,v))))))
+    [`(failed ,v) v]
+    [_ #f]))

--- a/scribble-test/tests/scribble/docs/manual-ex.rkt
+++ b/scribble-test/tests/scribble/docs/manual-ex.rkt
@@ -1,5 +1,7 @@
 #lang racket/base
-(require (for-syntax racket/base))
+(require (for-syntax racket/base)
+         racket/fixnum
+         racket/flonum)
 
 (provide (all-defined-out))
 
@@ -20,3 +22,11 @@
 (struct pn (x y))
 
 (define v 10)
+
+(define val:flvector (flvector 1.0 2.0))
+(define val:fxvector (fxvector 1 2))
+(define val:extflonum 1.0t0)
+(define val:kw '#:foo)
+(define val:list '(1 2 3 4))
+(define val:vector #(1 2 3 4))
+(define val:param (make-parameter 'foo))

--- a/scribble-test/tests/scribble/docs/manual.scrbl
+++ b/scribble-test/tests/scribble/docs/manual.scrbl
@@ -52,6 +52,9 @@ A function, again, not a link target, documented to return @racket[10] using a d
 
 @defparam[#:link-target? #f p k integer? #:value 10]{A parameter, again, with a documented default value.}
 
+@defparam[#:link-target? #f val:param k any/c #:auto-value]{A parameter with auto-value.}
+
+
 @defparam*[#:link-target? #f p k real? integer?]{A parameter, yet again.}
 
 @defparam*[#:link-target? #f p k real? integer? #:value 10]{A parameter, yet again, with a documented default value.}
@@ -71,6 +74,12 @@ A function, again, not a link target, documented to return @racket[10] using a d
 
 @defthing[#:link-target? #f v integer? #:value 12345678901234567890123456789012345678901234567890]{A thing, again, with a documented value that's too wide to fit on one line.}
 
+@defthing[#:link-target? #f val:flvector any/c #:auto-value]{Test auto-value flvector reading.}
+@defthing[#:link-target? #f val:fxvector any/c #:auto-value]{Test auto-value fxvector reading.}
+@defthing[#:link-target? #f val:extflonum any/c #:auto-value]{Test auto-value extflonum reading.}
+@defthing[#:link-target? #f val:kw any/c #:auto-value]{Test auto-value keyword reading.}
+@defthing[#:link-target? #f val:list any/c #:auto-value]{Test auto-value list reading.}
+@defthing[#:link-target? #f val:vector any/c #:auto-value]{Test auto-value vector reading.}
 
 @defstruct[pt ([x real?] [y real?])]{A structure type with extra name.}
 

--- a/scribble-test/tests/scribble/docs/manual.txt
+++ b/scribble-test/tests/scribble/docs/manual.txt
@@ -105,6 +105,13 @@ A parameter, again.
 
 A parameter, again, with a documented default value.
 
+(val:param) -> any/c  
+(val:param k) -> void?
+  k : any/c           
+ = 'foo               
+
+A parameter with auto-value.
+
 (p) -> integer?
 (p k) -> void? 
   k : real?    
@@ -154,6 +161,30 @@ v : integer?
 
 A thing, again, with a documented value that’s too wide to fit on one
 line.
+
+val:flvector : any/c = #fl(1.0 2.0)
+
+Test auto-value flvector reading.
+
+val:fxvector : any/c = #fx(1 2)
+
+Test auto-value fxvector reading.
+
+val:extflonum : any/c = 1.0t0
+
+Test auto-value extflonum reading.
+
+val:kw : any/c = '#:foo
+
+Test auto-value keyword reading.
+
+val:list : any/c = '(1 2 3 4)
+
+Test auto-value list reading.
+
+val:vector : any/c = #(1 2 3 4)
+
+Test auto-value vector reading.
 
 (struct pt (x y)                     
     #:extra-constructor-name make-pt)


### PR DESCRIPTION
Manually specifying `#:value` could be cumbersome. An example is `html-empty-tags` from the `xml` collection, which is a list of more than 10 symbols.
It is also error-prone, and could be out-of-sync from the actual value.

This PR adds a support for `#:auto-value` in `defparam` and `defthing` to automatically query the value from the `for-label` binding.

Thanks to @LiberalArtist for the help in https://github.com/racket/racket/pull/4807.