### PR TITLE
html renderer: correct the button group 

### DIFF
--- a/scribble-lib/scribble/manual-style.css
+++ b/scribble-lib/scribble/manual-style.css
@@ -31,29 +31,13 @@
     font-size: 1rem;
 }
 
-/** Begin headings */
-
-/* Hide the button group by default, but show them on hovering the heading title */
-.heading:hover > .button-group {
-    visibility: visible;
-}
-.button-group {
-    visibility: hidden;
-}
-
-.heading-anchor {
-    font-size: 60%;
-    /* A trick to color an emoji from https://stackoverflow.com/questions/32413731/color-for-unicode-emoji */
-    color: transparent;
-    text-shadow: 0 0 0 gray;
-    vertical-align: 5%;
-}
-.heading-source {
+/* Enable heading-source */
+.button-group > .heading-source {
+    visibility: inherit;
     cursor: pointer;
     user-select: none;
     color: gray;
 }
-/** End headings */
 
 /* embolden the "Racket Guide" and "Racket Reference" links on the TOC */
 /* there isn't an obvious tag in the markup that designates the top TOC page, which is called "start.scrbl" */

--- a/scribble-lib/scribble/scribble.css
+++ b/scribble-lib/scribble/scribble.css
@@ -514,3 +514,35 @@ ol ol ol ol { list-style-type: upper-alpha; }
     margin-left: 0;
   }
 }
+
+/** Begin headings */
+
+/* Hide the button group by default, but show them on hovering the heading title */
+.button-group {
+    padding-left: 0.3em;
+    visibility: hidden;
+    position: absolute;
+}
+.heading:hover > .button-group {
+    visibility: visible;
+}
+
+.button-group > a {
+    margin: 0 0.25em;
+}
+
+.button-group > a, .button-group > a:hover {
+    text-decoration: none;
+}
+
+.heading-anchor {
+    font-size: 60%;
+    /* A trick to color an emoji from https://stackoverflow.com/questions/32413731/color-for-unicode-emoji */
+    color: transparent;
+    text-shadow: 0 0 0 gray;
+    vertical-align: 5%;
+}
+
+.heading-source {
+    visibility: hidden;
+}


### PR DESCRIPTION
This PR fixes a couple of issues related to the button group.

- On `#lang scribble/base`, only show the "Link to here" button,
  and do so with correct styling.
- Make it possible for the button group to exceed the right margin
  to preserve the previous HTML layout.
- Place anchor at the beginning of the headings, not at the end,
  so that on navigation, we will see the full heading.

Thanks to @mflatt who reported some of the issues above and
helped with testing.

Fixes https://github.com/racket/scribble/issues/381