### PR TITLE
typeset: correct the form of `code:contract#` and `code:quote`

### DIFF
--- a/scribble-doc/scribblings/scribble/manual.scrbl
+++ b/scribble-doc/scribblings/scribble/manual.scrbl
@@ -310,7 +310,7 @@ A few other escapes are recognized symbolically:
       the sequence of @racket[_datum]s (including its coloring), but prefixed with a
       semi-colon.}
 
- @item{@racket[(#,(indexed-racket code:contract#) _datum ...)] is like
+ @item{@racket[(#,(indexed-racket code:contract#) _datum)] is like
        @racket[code:contract], but uses #; to prefix the contract.}
 
  @item{@as-index[@racketidfont{code:blank}] typesets as a blank space.}

--- a/scribble-lib/scribble/racket.rkt
+++ b/scribble-lib/scribble/racket.rkt
@@ -566,6 +566,7 @@
           [(and escapes?
                 (pair? (syntax-e c))
                 (eq? (syntax-e (car (syntax-e c))) 'code:quote))
+           (check-1-c c)
            (advance c init-line! srcless-step)
            (let ([quote-depth (to-quoted c expr? quote-depth out color? inc-src-col)])
              (out "(" (if (positive? quote-depth) value-color paren-color))


### PR DESCRIPTION
- `code:contract#` only allows one subform in the implementation, but the documentation allows many subforms.
- `code:quote` only allows one subform in the documentation, but the implementation allows many subforms.

This PR corrects both the implementation and the documentation so that the implementation and the documentation agree with each other.