### PR TITLE
Refactor racket.rkt

### DIFF
--- a/scribble-lib/scribble/racket.rkt
+++ b/scribble-lib/scribble/racket.rkt
@@ -548,24 +548,24 @@
         [(and escapes?
               (pair? (syntax-e c))
               (eq? (syntax-e (car (syntax-e c))) 'code:line))
-         (let ([l (cdr (syntax->list c))])
-           (for-each/i (loop init-line! quote-depth expr? #f)
-                       l
-                       #f))]
+         (define l (cdr (syntax->list c)))
+         (for-each/i (loop init-line! quote-depth expr? #f)
+                     l
+                     #f)]
         [(and escapes?
               (pair? (syntax-e c))
               (eq? (syntax-e (car (syntax-e c))) 'code:hilite))
-         (let ([l (syntax->list c)]
-               [h? highlight?])
-           (unless (and l (= 2 (length l)))
-             (error "bad code:redex: ~.s" (syntax->datum c)))
-           (advance c init-line! srcless-step)
-           (set! src-col (syntax-column (cadr l)))
-           (hash-set! next-col-map src-col dest-col)
-           (set! highlight? #t)
-           ((loop init-line! quote-depth expr? #f) (cadr l) #f)
-           (set! highlight? h?)
-           (set! src-col (add1 src-col)))]
+         (define l (syntax->list c))
+         (define h? highlight?)
+         (unless (and l (= 2 (length l)))
+           (error "bad code:redex: ~.s" (syntax->datum c)))
+         (advance c init-line! srcless-step)
+         (set! src-col (syntax-column (cadr l)))
+         (hash-set! next-col-map src-col dest-col)
+         (set! highlight? #t)
+         ((loop init-line! quote-depth expr? #f) (cadr l) #f)
+         (set! highlight? h?)
+         (set! src-col (add1 src-col))]
         [(and escapes?
               (pair? (syntax-e c))
               (eq? (syntax-e (car (syntax-e c))) 'code:quote))
@@ -717,28 +717,28 @@
                               [(vector? (syntax-e c))
                                (vector->short-list (syntax-e c) syntax-e)]
                               [(struct? (syntax-e c))
-                               (let ([l (vector->list (struct->vector (syntax-e c)))])
-                                 ;; Need to build key datum, syntax-ize it internally, and
-                                 ;;  set the overall width to fit right:
-                                 (if (and expr? (zero? quote-depth))
-                                     (cdr l)
-                                     (cons (let ([key (syntax-ize (prefab-struct-key (syntax-e c))
-                                                                  (+ 3 (or (syntax-column c) 0))
-                                                                  (or (syntax-line c) 1))]
-                                                 [end (if (pair? (cdr l))
-                                                          (and (equal? (syntax-line c) (syntax-line (cadr l)))
-                                                               (syntax-column (cadr l)))
-                                                          (and (syntax-column c)
-                                                               (+ (syntax-column c) (syntax-span c))))])
-                                             (if end
-                                                 (datum->syntax #f
-                                                                (syntax-e key)
-                                                                (vector #f (syntax-line key)
-                                                                        (syntax-column key)
-                                                                        (syntax-position key)
-                                                                        (max 1 (- end 1 (syntax-column key)))))
-                                                 end))
-                                           (cdr l))))]
+                               (define l (vector->list (struct->vector (syntax-e c))))
+                               ;; Need to build key datum, syntax-ize it internally, and
+                               ;;  set the overall width to fit right:
+                               (if (and expr? (zero? quote-depth))
+                                   (cdr l)
+                                   (cons (let ([key (syntax-ize (prefab-struct-key (syntax-e c))
+                                                                (+ 3 (or (syntax-column c) 0))
+                                                                (or (syntax-line c) 1))]
+                                               [end (if (pair? (cdr l))
+                                                        (and (equal? (syntax-line c) (syntax-line (cadr l)))
+                                                             (syntax-column (cadr l)))
+                                                        (and (syntax-column c)
+                                                             (+ (syntax-column c) (syntax-span c))))])
+                                           (if end
+                                               (datum->syntax #f
+                                                              (syntax-e key)
+                                                              (vector #f (syntax-line key)
+                                                                      (syntax-column key)
+                                                                      (syntax-position key)
+                                                                      (max 1 (- end 1 (syntax-column key)))))
+                                               end))
+                                         (cdr l)))]
                               [(struct-proxy? (syntax-e c))
                                (struct-proxy-content (syntax-e c))]
                               [(forced-pair? (syntax-e c))
@@ -910,13 +910,13 @@
          (set! src-col (+ src-col (syntax-span c)))]
         [(graph-defn? (syntax-e c))
          (advance c init-line! srcless-step)
-         (let ([bx (graph-defn-bx (syntax-e c))])
-           (out (iformat "#~a=" (unbox bx))
-                (if (positive? quote-depth)
-                    value-color
-                    paren-color))
-           (set! src-col (+ src-col 3))
-           ((loop init-line! quote-depth expr? #f) (graph-defn-r (syntax-e c)) #f))]
+         (define bx (graph-defn-bx (syntax-e c)))
+         (out (iformat "#~a=" (unbox bx))
+              (if (positive? quote-depth)
+                  value-color
+                  paren-color))
+         (set! src-col (+ src-col 3))
+         ((loop init-line! quote-depth expr? #f) (graph-defn-r (syntax-e c)) #f)]
         [(and (keyword? (syntax-e c)) expr?)
          (advance c init-line! srcless-step)
          (let ([quote-depth (to-quoted c expr? quote-depth out color? inc-src-col)])

--- a/scribble-lib/scribble/racket.rkt
+++ b/scribble-lib/scribble/racket.rkt
@@ -1205,8 +1205,7 @@
      (datum->syntax (just-context-ctx v)
                     (syntax-e s)
                     s
-                    s
-                    (just-context-ctx v))]
+                    s)]
     [(alternate-display? v)
      (define s (do-syntax-ize (alternate-display-id v) col line ht #f qq #f))
      (syntax-property s

--- a/scribble-lib/scribble/racket.rkt
+++ b/scribble-lib/scribble/racket.rkt
@@ -104,8 +104,6 @@
 (define current-meta-list 
   (make-parameter null))
 
-(define defined-names (make-hasheq))
-
 (define-struct (sized-element element) (length))
 
 (define-struct (spaces element) (cnt))

--- a/scribble-lib/scribble/racket.rkt
+++ b/scribble-lib/scribble/racket.rkt
@@ -135,10 +135,8 @@
                    (hspace cnt)
                    (literalize-spaces (substring i (cdar m))))
                   cnt)]
-    [else
-     (if leading?
-         (nonbreak-leading-hyphens i)
-         i)]))
+    [leading? (nonbreak-leading-hyphens i)]
+    [else i]))
 
 
 (define line-breakable-space (make-element 'tt " "))

--- a/scribble-lib/scribble/racket.rkt
+++ b/scribble-lib/scribble/racket.rkt
@@ -342,7 +342,7 @@
          [first (if escapes?
                     (syntax-case c (code:line)
                       [(code:line e . rest) #'e]
-                      [else c])
+                      [_ c])
                     c)]
          [init-col (or (syntax-column first) 0)]
          [src-col init-col]
@@ -1052,7 +1052,7 @@
                                 (and (identifier? #'esc)
                                      (free-identifier=? #'esc uncode-id))
                                 #'e]
-                               [else (stx->loc-s-expr (syntax-e v))]))])
+                               [_ (stx->loc-s-expr (syntax-e v))]))])
                     (let ([prop (syntax-property v 'paren-shape)])
                       (if prop
                           `(,#'stx-prop ,mk 'paren-shape ,prop)

--- a/scribble-lib/scribble/racket.rkt
+++ b/scribble-lib/scribble/racket.rkt
@@ -798,15 +798,15 @@
         [(box? (syntax-e c))
          (advance c init-line! srcless-step)
          (let ([quote-depth (to-quoted c expr? quote-depth out color? inc-src-col)])
-           (if (and expr? (zero? quote-depth))
-               (begin
-                 (out "(" paren-color)
-                 (out "box" symbol-color)
-                 (out " " #f)
-                 (set! src-col (+ src-col 5)))
-               (begin
-                 (out "#&" value-color)
-                 (set! src-col (+ src-col 2))))
+           (cond
+             [(and expr? (zero? quote-depth))
+              (out "(" paren-color)
+              (out "box" symbol-color)
+              (out " " #f)
+              (set! src-col (+ src-col 5))]
+             [else
+              (out "#&" value-color)
+              (set! src-col (+ src-col 2))])
            (hash-set! next-col-map src-col dest-col)
            ((loop init-line! (if expr? quote-depth +inf.0) expr? #f) (unbox (syntax-e c)) #f)
            (when (and expr? (zero? quote-depth))


### PR DESCRIPTION
This PR consists of two parts: semi-automatic fixes by Resyntax, and manual fixes.

### Resyntax fixes

Resyntax fixes are commits with the prefix `resyntax:`. Each commit corresponds to fixes due to a rule. The methodology to produce fixes is as follows:

1. Run Resyntax, and pick "the first fix".
2. Apply all fixes with the same rule as "the first fix". 
3. Re-run Resyntax again to possibly get more fixes, and go to step 3 until we reach the fixed point.

Resyntax is modified to omit some rules that are not suitable for the file, but it is also made more lenient in presence of comments (https://github.com/jackfirth/resyntax/issues/232), making it possible to discover fixes that the standard Resyntax can't discover.