### PR TITLE
Refine the grammar of `field-name` in `defstruct`.

### DIFF
--- a/scribble-doc/scribblings/scribble/manual.scrbl
+++ b/scribble-doc/scribblings/scribble/manual.scrbl
@@ -1467,16 +1467,20 @@ Examples:
 
 
 @deftogether[(
-@defform[       (defstruct* maybe-link struct-name ([field-name contract-expr-datum] ...)
+@defform[       (defstruct* maybe-link struct-name ([field contract-expr-datum] ...)
                   maybe-mutable maybe-non-opaque maybe-constructor
                   pre-flow ...)]
-@defform/subs[  (defstruct maybe-link struct-name ([field-name contract-expr-datum] ...)
+@defform/subs[  (defstruct maybe-link struct-name ([field contract-expr-datum] ...)
                   maybe-mutable maybe-non-opaque maybe-constructor
                   pre-flow ...)
                ([maybe-link code:blank
                             (code:line #:link-target? link-target?-expr)]
                 [struct-name id
                              (id super-id)]
+                [field field-id
+                       (field-id field-option ...)]
+                [field-option #:mutable
+                              #:auto]
                 [maybe-mutable code:blank
                                #:mutable]
                 [maybe-non-opaque code:blank
@@ -1498,18 +1502,18 @@ Examples:
 An example using @racket[defstruct]:
 @codeblock[#:keep-lang-line? #f]|{
 #lang scribble/manual
-@defstruct[sandwich ([protein ingredient?] [sauce ingredient?])]{
+@defstruct[sandwich ([(protein #:mutable) ingredient?] [sauce ingredient?])]{
   A structure type for sandwiches. Sandwiches are a pan-human foodstuff
   composed of a partially-enclosing bread material and various
-  ingredients.
+  ingredients. The @racketid[protein] field is mutable.
 }
 }|
 @doc-render-examples[
   @defstruct[#:link-target? #f
-             sandwich ([protein ingredient?] [sauce ingredient?])]{
+             sandwich ([(protein #:mutable) ingredient?] [sauce ingredient?])]{
     A structure type for sandwiches. Sandwiches are a pan-human foodstuff
     composed of a partially-enclosing bread material and various
-    ingredients.
+    ingredients. The @racketid[protein] field is mutable.
   }]
 
 Additionally, an example using @racket[defstruct*]:

--- a/scribble-lib/scribble/private/manual-proc.rkt
+++ b/scribble-lib/scribble/private/manual-proc.rkt
@@ -17,6 +17,7 @@
          "manual-method.rkt"
          "manual-ex.rkt"
          "on-demand.rkt"
+         racket/match
          racket/string
          racket/list
          racket/contract
@@ -897,10 +898,15 @@
                                (append (if (pair? name) name (list name))
                                        (map field-name fields)))
                           (map (lambda (f)
-                                 (if (pair? (car f))
-                                     (+ 3 2 (string-length (keyword->string
-                                                            (cadar f))))
-                                     0))
+                                 (match (car f)
+                                   [(? symbol?) 0]
+                                   [(list name) 2] ;; the extra [ ]
+                                   [(list* name field-opts)
+                                    ;; '[' ']'
+                                    (apply + 2
+                                           (for/list ([field-opt (in-list field-opts)])
+                                             ;; and " #:"
+                                             (+ 3 (string-length (keyword->string field-opt)))))]))
                                fields)))])
             (cond
               [(and (short-width . < . max-proto-width)

--- a/scribble-test/tests/scribble/docs/manual-ex.rkt
+++ b/scribble-test/tests/scribble/docs/manual-ex.rkt
@@ -20,6 +20,7 @@
 
 (define-struct pt (x y))
 (struct pn (x y))
+(struct counter (name [count #:mutable]))
 
 (define v 10)
 

--- a/scribble-test/tests/scribble/docs/manual.scrbl
+++ b/scribble-test/tests/scribble/docs/manual.scrbl
@@ -99,6 +99,14 @@ A function, again, not a link target, documented to return @racket[10] using a d
 
 @defstruct[#:link-target? #f pt ([x real?] [y real?]) #:mutable]{A mutable structure type with extra name, again.}
 
+@defstruct*[#:link-target? #f counter ([name symbol?] [(count) exact-nonnegative-integer?])]{A struct with an (empty) list of field options.}
+
+@defstruct*[counter ([name symbol?] [(count #:mutable) exact-nonnegative-integer?])]{Another struct with a mutable field.}
+
+@defstruct*[#:link-target? #f counter ([name symbol?] [(count #:auto) exact-nonnegative-integer?])]{A struct with an automatic field.}
+
+@defstruct*[#:link-target? #f counter ([name symbol?] [(count #:auto #:mutable) exact-nonnegative-integer?])]{A struct with both.}
+
 @defstruct[a-struct-with-an-extremely-long-name-and-no-fields ()]{Used to raise error, taking car of empty fields list. Reported by Carlos Lopez, 2017-03-11.}
 
 

--- a/scribble-test/tests/scribble/docs/manual.txt
+++ b/scribble-test/tests/scribble/docs/manual.txt
@@ -248,6 +248,30 @@ A structure type with extra name, again.
 
 A mutable structure type with extra name, again.
 
+(struct counter (name [count]))     
+  name : symbol?                    
+  count : exact-nonnegative-integer?
+
+A struct with an (empty) list of field options.
+
+(struct counter (name [count #:mutable]))
+  name : symbol?                         
+  count : exact-nonnegative-integer?     
+
+Another struct with a mutable field.
+
+(struct counter (name [count #:auto]))
+  name : symbol?                      
+  count : exact-nonnegative-integer?  
+
+A struct with an automatic field.
+
+(struct counter (name [count #:auto #:mutable]))
+  name : symbol?                                
+  count : exact-nonnegative-integer?            
+
+A struct with both.
+
 (struct a-struct-with-an-extremely-long-name-and-no-fields ()
     #:extra-constructor-name                                 
     make-a-struct-with-an-extremely-long-name-and-no-fields) 


### PR DESCRIPTION
The `defstruct[*]` form does support field options. Therefore use the same grammar as [`[define-]struct`](https://docs.racket-lang.org/reference/define-struct.html#%28form._%28%28lib._racket%2Fprivate%2Fbase..rkt%29._struct%29%29) in the documentation.