### PR TITLE
Clarify contract for `pre-content` in `link`.

### DIFF
--- a/scribble-doc/scribblings/scribble/manual.scrbl
+++ b/scribble-doc/scribblings/scribble/manual.scrbl
@@ -1872,9 +1872,9 @@ of @racket[id].}
 
 Compatibility alias for @racket[racketlink].}
 
-@defproc[(link [url string?] [pre-content any/c] ...
-                [#:underline? underline? any/c #t]
-                [#:style style (or/c style? string? symbol? #f) (if underline? #f "plainlink")]) 
+@defproc[(link [url string?] [pre-content pre-content?] ...
+               [#:underline? underline? any/c #t]
+               [#:style style (or/c style? string? symbol? #f) (if underline? #f "plainlink")])
          element?]{
 
 Alias of @racket[hyperlink] for backward compatibility.}


### PR DESCRIPTION
`[pre-content any/c]` -> `[pre-content pre-content?]`