### PR TITLE
Add Resyntax Autofixer workflow

### DIFF
--- a/.github/workflows/resyntax-autofixer.yml
+++ b/.github/workflows/resyntax-autofixer.yml
@@ -1,0 +1,62 @@
+name: Resyntax Autofixer
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 3"
+
+jobs:
+  autofix:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4.1.7
+        # See https://github.com/actions/checkout/issues/118.
+        with:
+          fetch-depth: 0
+      - name: Install Racket
+        uses: Bogdanp/setup-racket@v1.11
+        with:
+          version: current
+          packages: resyntax
+          local_catalogs: $GITHUB_WORKSPACE
+          dest: '"${HOME}/racketdist-current-CS"'
+          sudo: never
+      - name: Register local packages
+        run: |
+          raco pkg install -i --auto --no-setup --skip-installed scribble-test scribble-doc
+          raco pkg update --auto --no-setup scribble-text-lib scribble-html-lib scribble-lib scribble-doc scribble-test scribble
+      - name: Install local packages
+        run: raco setup --pkgs scribble scribble-doc scribble-html-lib scribble-lib scribble-test scribble-text-lib
+      - name: Create a new branch
+        run: git checkout -b autofix-${{ github.run_number }}-${{ github.run_attempt }}
+      - name: Run Resyntax
+        run: racket -l- resyntax/cli fix --directory . --max-fixes 10 --output-as-commit-message >> /tmp/resyntax-output.txt
+      - name: Create pull request
+        uses: actions/github-script@v6.4.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { readFile, writeFile } = require('fs/promises');
+            const commitMessageBody = await readFile('/tmp/resyntax-output.txt', { encoding: 'utf8' });
+            const commitMessageTitle = "Automated Resyntax fixes";
+            const commitMessage = commitMessageTitle + "\n\n" + commitMessageBody;
+            await writeFile('/tmp/resyntax-commit-message.txt', commitMessage);
+            await exec.exec('git config user.name "GitHub Actions"');
+            await exec.exec('git config user.email "actions@github.com"');
+            await exec.exec('git commit --all --file=/tmp/resyntax-commit-message.txt');
+            await exec.exec('git push --set-upstream origin autofix-${{ github.run_number }}-${{ github.run_attempt }}');
+            await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: commitMessageTitle,
+              head: "autofix-${{ github.run_number }}-${{ github.run_attempt }}",
+              base: "master",
+              body: commitMessageBody,
+              maintainer_can_modify: true,
+            });


### PR DESCRIPTION
Similar to the [autofixer in the DrRacket repository](https://github.com/racket/scribble/blob/master/.github/workflows/resyntax-analyze.yml), this workflow runs Resyntax on the repository once a week. A handful of suggested fixes are gathered into a pull request and opened for review.