### PR TITLE
Add `exported-index-desc*`

### DIFF
--- a/scribble-doc/scribblings/scribble/core.scrbl
+++ b/scribble-doc/scribblings/scribble/core.scrbl
@@ -1105,11 +1105,10 @@ The @racket[entry-seq] list must have the same length as
 final document.
 
 The @racket[desc] field provides additional information about the
-index entry as supplied by the entry creator. For example, a reference
-to a procedure binding can be recognized when @racket[desc] is an
-instance of @racket[procedure-index-desc]. See
-@racketmodname[scribble/manual-struct] for other typical types of
-@racket[desc] values.
+index entry as supplied by the entry creator. For example, a reference to
+a procedure binding can be recognized when @racket[desc] is an instance of
+@racket[exported-index-desc*] with the @racket['("procedure")] kind.
+See @racketmodname[scribble/manual-struct] for other types of @racket[desc] values.
 
 See also @racket[index].}
 

--- a/scribble-doc/scribblings/scribble/manual.scrbl
+++ b/scribble-doc/scribblings/scribble/manual.scrbl
@@ -2250,43 +2250,111 @@ correspond to the documented name of the binding and the primary
 modules that export the documented name (but this list is not
 exhaustive, because new modules can re-export the binding).}
 
+@defstruct[(exported-index-desc* exported-index-desc) ([extras (hash/dc [k symbol?]
+                                                                        [v (k)
+                                                                           (case k
+                                                                             [(kind) string?]
+                                                                             [(hidden?) boolean?]
+                                                                             [(method-name) symbol?]
+                                                                             [(constructor?) boolean?]
+                                                                             [(class-tag) tag?]
+                                                                             [else any/c])]
+                                                                        #:immutable #t)])]{
+
+Like @racket[exported-index-desc], but with additional optional
+information in an @racket[extras] hash table. All values in the ahsh
+table should be @racket[write]able in the sense that @racket[read]
+will reconstruct the value. Any symbol is allowed as a key in
+@racket[extras], but some are well-known:
+
+@itemlist[
+
+ @item{@racket['kind]: A string describing the binding's category,
+       such as @racket["procedure"] or @racket["class"]. Like most
+       other values in @racket[extras], this string is @emph{not}
+       added to the index entry's main text as shown to a user, but it
+       be rendered by some interfaces, such as to the side or in hover
+       text.}
+
+ @item{@racket['hidden?]: A boolean indicating that the index entry
+       describes a binding that is covered from a user's perspective
+       by a different index entry. These are considered redundant and
+       filtered from index rendering.}
+
+ @item{@racket['method-name]: A symbol indicating that the index entry
+       describes a method for the class that is in the @racket[name]
+       field, and the symbol is the method's name.}
+
+ @item{@racket['constructor?]: A boolean indicating that the index
+       entry describes a class's constructor, separate from an index
+       entry for the class. A constructor normally also has
+       @racket['hidden?] as true.}
+
+ @item{@racket['class-tag]: A tag that links to the class's main entry
+       in the case of a method or constructor index entry, where the
+       @racket[name] field has the class name in both cases.}
+
+]
+
+The @racket[exported-index-desc*] struct is preferable over
+other index entry descriptions below.
+
+@history[#:added "1.53"]}
+
 @defstruct[(form-index-desc exported-index-desc) ()]{
+
+@deprecated[#:what "struct" @racket[exported-index-desc*]]
 
 Indicates that the index entry corresponds to the definition of a
 syntactic form via @racket[defform] and company.}
 
+
 @defstruct[(procedure-index-desc exported-index-desc) ()]{
+
+@deprecated[#:what "struct" @racket[exported-index-desc*]]
 
 Indicates that the index entry corresponds to the definition of a
 procedure binding via @racket[defproc] and company.}
 
 @defstruct[(thing-index-desc exported-index-desc) ()]{
 
+@deprecated[#:what "struct" @racket[exported-index-desc*]]
+
 Indicates that the index entry corresponds to the definition of a
 binding via @racket[defthing] and company.}
 
 @defstruct[(struct-index-desc exported-index-desc) ()]{
+
+@deprecated[#:what "struct" @racket[exported-index-desc*]]
 
 Indicates that the index entry corresponds to the definition of a
 structure type via @racket[defstruct] and company.}
 
 @defstruct[(class-index-desc exported-index-desc) ()]{
 
+@deprecated[#:what "struct" @racket[exported-index-desc*]]
+
 Indicates that the index entry corresponds to the definition of a
 class via @racket[defclass] and company.}
 
 @defstruct[(interface-index-desc exported-index-desc) ()]{
+
+@deprecated[#:what "struct" @racket[exported-index-desc*]]
 
 Indicates that the index entry corresponds to the definition of an
 interface via @racket[definterface] and company.}
 
 @defstruct[(mixin-index-desc exported-index-desc) ()]{
 
+@deprecated[#:what "struct" @racket[exported-index-desc*]]
+
 Indicates that the index entry corresponds to the definition of a
 mixin via @racket[defmixin] and company.}
 
 @defstruct[(method-index-desc exported-index-desc) ([method-name symbol?]
                                                     [class-tag tag?])]{
+
+@deprecated[#:what "struct" @racket[exported-index-desc*]]
 
 Indicates that the index entry corresponds to the definition of an
 method via @racket[defmethod] and company. The @racket[_name] field
@@ -2296,6 +2364,8 @@ The @racket[class-tag] field provides a pointer to the start of the
 documentation for the method's class or interface.}
 
 @defstruct[(constructor-index-desc exported-index-desc) ([class-tag tag?])]{
+
+@deprecated[#:what "struct" @racket[exported-index-desc*]]
 
 Indicates that the index entry corresponds to a constructor
 via @racket[defconstructor] and company. The @racket[_name] field

--- a/scribble-lib/info.rkt
+++ b/scribble-lib/info.rkt
@@ -23,7 +23,7 @@
 
 (define pkg-authors '(mflatt eli))
 
-(define version "1.52")
+(define version "1.53")
 
 (define license
   '((Apache-2.0 OR MIT)

--- a/scribble-lib/scribble/base.rkt
+++ b/scribble-lib/scribble/base.rkt
@@ -904,7 +904,15 @@
                      rows)))
   (define contents
     (lambda (renderer sec ri)
-      (define l (get-index-entries sec ri))
+      (define l (for/list ([e (in-list (get-index-entries sec ri))]
+                           #:unless (let* ([desc (list-ref e 3)]
+                                           [desc (if (delayed-index-desc? desc)
+                                                     (delayed-index-desc-content desc ri)
+                                                     desc)])
+                                      (or (constructor-index-desc? desc)
+                                          (and (exported-index-desc*? desc)
+                                               (hash-ref (exported-index-desc*-extras desc) 'hidden? #f)))))
+                  e))
       (define manual-newlines? (send renderer index-manual-newlines?))
       (define alpha-starts (make-hasheq))
       (define alpha-row

--- a/scribble-lib/scribble/core.rkt
+++ b/scribble-lib/scribble/core.rkt
@@ -458,6 +458,10 @@
 (define (delayed-block-blocks p ri)
   (hash-ref (resolve-info-delays ri) p))
 
+(provide delayed-index-desc-content)
+(define (delayed-index-desc-content e ri)
+  (hash-ref (resolve-info-delays ri) e))
+
 (provide current-serialize-resolve-info)
 (define current-serialize-resolve-info (make-parameter #f))
 

--- a/scribble-lib/scribble/manual-struct.rkt
+++ b/scribble-lib/scribble/manual-struct.rkt
@@ -3,12 +3,24 @@
          "private/provide-structs.rkt"
          racket/contract/base)
 
+(define kind/c (listof (or/c string? (list/c 'code string?))))
+
 (provide-structs
  [module-path-index-desc ()]
  [(language-index-desc module-path-index-desc) ()]
  [(reader-index-desc module-path-index-desc) ()]
  [exported-index-desc ([name symbol?]
                        [from-libs (listof module-path?)])]
+ [(exported-index-desc* exported-index-desc) ([extras (hash/dc [k symbol?]
+                                                               [v (k)
+                                                                  (case k
+                                                                    [(kind) string?]
+                                                                    [(hidden?) boolean?]
+                                                                    [(method-name) symbol?]
+                                                                    [(constructor?) boolean?]
+                                                                    [(class-tag) tag?]
+                                                                    [else any/c])]
+                                                               #:immutable #t)])]
  [(method-index-desc exported-index-desc) ([method-name symbol?]
                                            [class-tag tag?])]
  [(constructor-index-desc exported-index-desc) ([class-tag tag?])]

--- a/scribble-lib/scribble/private/manual-bind.rkt
+++ b/scribble-lib/scribble/private/manual-bind.rkt
@@ -264,11 +264,12 @@
                                            syntax-link-color
                                            value-link-color)
                                        (list str)))))
-                                   ((if form?
-                                        make-form-index-desc
-                                        make-procedure-index-desc)
+                                   (make-exported-index-desc*
                                     id
-                                    (list mod-path)))))))
+                                    (list mod-path)
+                                    (hash 'kind (if form?
+                                                    "syntax"
+                                                    "procedure"))))))))
     redirects)))
 
 

--- a/scribble-lib/scribble/private/manual-class.rkt
+++ b/scribble-lib/scribble/private/manual-class.rkt
@@ -190,7 +190,7 @@
           (flow-paragraphs
            (decode-flow (build-body decl post)))))))))))
 
-(define (*class-doc kind stx-id super all-intfs ranges whole-page? make-index-desc link?)
+(define (*class-doc kind stx-id super all-intfs ranges whole-page? link?)
   (define intfs (for/list ([intf (in-list all-intfs)])
                   (syntax-case intf ()
                     [(#:no-inherit intf) #'intf]
@@ -228,7 +228,10 @@
                              (list ref-content)
                              (with-exporting-libraries
                                  (lambda (libs)
-                                   (make-index-desc (syntax-e stx-id) libs)))))
+                                   (make-exported-index-desc*
+                                    (syntax-e stx-id)
+                                    libs
+                                    (hash 'kind (symbol->string kind)))))))
                            tag)))
                        content)]
                   [else (to-element stx-id)])
@@ -319,7 +322,6 @@
                                        (list (quote-syntax intf) ...)
                                        null
                                        whole-page?
-                                       make-class-index-desc
                                        link?)))
                    (flatten-splices (list body ...))))
      link?)))
@@ -355,7 +357,6 @@
                                   (list (quote-syntax intf) ...)
                                   null
                                   whole-page?
-                                  make-interface-index-desc
                                   link?)))
                    (list body ...)))
      link?)))
@@ -384,7 +385,6 @@
                                   (list (quote-syntax domain) ...)
                                   (list (quote-syntax range) ...)
                                   whole-page?
-                                  make-mixin-index-desc
                                   link?)))
                    (list body ...)))
      link?)))

--- a/scribble-lib/scribble/private/manual-form.rkt
+++ b/scribble-lib/scribble/private/manual-form.rkt
@@ -305,7 +305,7 @@
 
 (define (meta-symbol? s) (memq s '(... ...+ ?)))
 
-(define (defform-site kw-id)
+(define (defform-site kw-id #:kind [kind "syntax"])
   (define target-maker (id-to-form-target-maker kw-id #t))
   (define-values (content ref-content) (definition-site (syntax-e kw-id) kw-id #t))
   (if target-maker
@@ -321,14 +321,16 @@
                (list ref-content)
                (with-exporting-libraries
                    (lambda (libs)
-                     (make-form-index-desc (syntax-e kw-id)
-                                           libs))))
+                     (make-exported-index-desc* (syntax-e kw-id)
+                                                libs
+                                                (hash 'kind kind)))))
               content)
           tag
           ref-content)))
       content))
 
 (define (*defforms kind link? kw-id forms form-procs subs sub-procs contract-procs content-thunk)
+  (define kind* (or kind "syntax"))
   (parameterize ([current-meta-list '(... ...+)])
     (make-box-splice
      (cons
@@ -342,7 +344,7 @@
                      [form-proc (in-list form-procs)]
                      [i (in-naturals)])
             (list
-             ((if (zero? i) (add-background-label (or kind "syntax")) values)
+             ((if (zero? i) (add-background-label kind*) values)
               (list
                ((or form-proc
                     (lambda (x)
@@ -351,7 +353,7 @@
                 (and kw-id
                      (if (eq? form (car forms))
                          (if link?
-                             (defform-site kw-id)
+                             (defform-site kw-id #:kind kind*)
                              (to-element #:defn? #t kw-id))
                          (to-element #:defn? #t kw-id))))))))
           (if (null? sub-procs)


### PR DESCRIPTION
This is a revised version of #328

The `exported-index-desc*` struct adds an `extras` field that is a composable catch-all for extensions. The set of keys in `extras` is meant to be a mixture of well-known keys and third-party keys that a producer and consumer might agree on; the contract on `exported-index-desc*` checks that well-known keys have values of the right shape.

The initial well-known keys are `'kind` (corresponding to the text in the upper right of a documentation box), `'hidden?` (indicates an entry that looks redundant to a user, so it should be filtered out when rendering), `'method`, `'constructor?`, and `class-tag`. Those last 3 cover the information that used to be provided by `method-index-desc` and `constructor-index-desc`.

For a method, the index text now includes `(method of <class>)` text that is otherwise added as a special case for `method-index-desc` in the documentation search panel. The intent here is to put those decisions more consistently in the document producer, not the index consumer. Also, `(struct)` is added to struct type entries, because there's no naming convention that makes that otherwise apparent.

Accompanying change to search generation: https://github.com/mflatt/racket/tree/indexdesc