### PR TITLE
scribble dark-mode

### DIFF
--- a/scribble-lib/scribble/manual-racket.css
+++ b/scribble-lib/scribble/manual-racket.css
@@ -324,3 +324,120 @@ tbody > tr:first-child > td > .together {
     padding: 0.2rem;
     text-align: left;
 }
+
+@media (prefers-color-scheme: dark) {
+    a.RktValDef, a.RktStxDef, a.RktSymDef,
+    span.RktValDef, span.RktStxDef, span.RktSymDef {
+        color: #b5c2e6;
+
+    }
+
+    .inherited {
+        background-color: #9E1C1F;
+
+    }
+
+    .RktValLink, .RktStxLink, .RktModLink {
+        color: #e6ccff;
+    }
+
+    h2 a.RktStxLink, h3 a.RktStxLink, h4 a.RktStxLink, h5 a.RktStxLink,
+    h2 a.RktValLink, h3 a.RktValLink, h4 a.RktValLink, h5 a.RktValLink,
+    h2 .RktSym, h3 .RktSym, h4 .RktSym, h5 .RktSym,
+    h2 .RktMod, h3 .RktMod, h4 .RktMod, h5 .RktMod,
+    h2 .RktVal, h3 .RktVal, h4 .RktVal, h5 .RktVal,
+    h2 .RktPn, h3 .RktPn, h4 .RktPn, h5 .RktPn {
+        color: #e6ccff;
+
+    }
+
+    .tocset td a.tocviewselflink .RktValLink,
+    .tocset td a.tocviewselflink .RktStxLink,
+    .tocset td a.tocviewselflink .RktMod,
+    .tocset td a.tocviewselflink .RktSym {
+        color: #e6ccff;
+    }
+
+    .toptoclink .RktStxLink, .toclink .RktStxLink,
+    .toptoclink .RktValLink, .toclink .RktValLink,
+    .toptoclink .RktModLink, .toclink .RktModLink {
+        color: #e6ccff;
+
+    }
+
+    .tocset .RktValLink, .tocset .RktStxLink, .tocset .RktModLink, .tocset .RktSym {
+        color: #e6ccff;
+
+    }
+
+    .SVInsetFlow .RktVar {
+        color: #e6ccff;
+
+    }
+
+    .RktVar {
+        color: #b5c2e6;
+
+    }
+
+    .RktRes {
+        color: #ffc9d1;
+    }
+
+    .RktSym {
+        color: #b5c2e6;
+
+    }
+
+    .RktOut {
+        color: #e6ccff;
+    }
+
+    .defmodule {
+        border-top: 1px dotted #99b;
+        background-color: #2c2e35;
+        border-bottom-left-radius: 5px;
+        border-bottom-right-radius: 5px;
+    }
+
+    .defmodule a {
+        color: #e6ccff;
+    }
+
+    .defmodule .RktPn {
+        color: #b35f61;
+    }
+
+    .RktVal {
+        color: #ffc9d1;
+    }
+
+    .RktMeta {
+        color: #e6ccff;
+    }
+
+    .RktPn {
+        color: #b35f61;
+    }
+
+    .RktErr {
+        color: #9E1C1F;
+    }
+
+    .RktOpt {
+        color: #b5c2e6;
+    }
+
+    .SHistory {
+        color: #ffc9d1;
+    }
+
+    .stt {
+        color: #e6ccff;
+    }
+
+    .together {
+        border-top: 1px dotted #e6ccff;
+        padding: 8px;
+    }
+}

--- a/scribble-lib/scribble/manual-style.css
+++ b/scribble-lib/scribble/manual-style.css
@@ -790,3 +790,116 @@ blockquote > blockquote.SVInsetFlow {
         margin-left: 0;
     }
 }
+
+@media (prefers-color-scheme: dark){
+    .tocview{
+        background-color: #171920;
+    }
+
+    body {
+        background-color: #282828;
+        color: #ebebeb;
+    }
+
+    .tocset{
+        background-color: #171920;
+    }
+
+    .navsettop, .navsetbottom{
+        background-color: #171920;
+    }
+
+    .navright a {
+        color: #ebebeb;
+    }
+
+    .navleft a {
+        color: #ebebeb;
+    }
+
+    h1, h2, h3, h4, h5, h6, h7, h8{
+        color: #b5c2e6;
+        text-shadow: 2px 2px 2px rgba(0, 0, 0, 0.1);
+        border-bottom: 1px dotted #8AA9FF;
+    }
+
+    .boxed {
+        background-color: #2c2e35;
+        background: #2c2e35;
+        border-bottom-left-radius: 5px;
+        border-bottom-right-radius: 5px;
+        border-top: 1px dotted #99b;
+        margin: 0em;
+        padding-left: 0.5em;
+    }
+
+    .SVInsetFlow a, .SCodeFlow a {
+        color: #b5c2e6;
+    }
+
+    .SCodeFlow .RktSym {
+        color: #e6ccff;
+    }
+
+    .tocset td a{
+        color: #b5c2e6;
+    }
+
+    .tocset td a.tocviewselflink{
+        color: #b5c2e6;
+    }
+
+    a, .toclink, .toptoclink, .tocviewlink, .tocviewselflink, .tocviewtoggle, .plainlink,
+    .techinside, .techoutside:hover, .techinside:hover{
+        color: #e6ccff;
+    }
+
+    h3, h4, h5, h6, h7, h8 {
+        border-top: 0px;
+        padding: 15px;
+    }
+
+    .refcolumn {
+        background: #2c2e35;
+        border: 1px solid #e6ccff;
+        border-left: 0.4rem solid #e6ccff;
+        border-radius: 5px;
+    }
+
+    .SCodeFlow {
+        border-left: 1px dotted #b35f61;
+        background: #171920;
+        border-radius: 5px;
+        margin: 0;
+        margin-top: 2em;
+        padding-left: 0.5em;
+        padding-top: 0.3em;
+        padding-bottom: 0.4em;
+    }
+
+    .SCodeFlow .RktRes {
+        padding-left: 1.5em;
+    }
+
+    .SCodeFlow .RktOut {
+        padding-left: 1.5em;
+    }
+
+    .SCodeFlow .RktErr {
+        padding-left: 1.5em;
+    }
+
+    .searchbox {
+        background-color: #171920;
+        border: 1px solid #b5c2e6;
+        color: white;
+    }
+
+    .tocviewsublist, .tocviewsublistonly, .tocviewsublisttop, .tocviewsublistbottom {
+        border-left: 1px dotted #b35f61;
+    }
+
+    .tocsublist td {
+        border-left: 1px dotted #b35f61;
+    }
+}


### PR DESCRIPTION
Hi folks!

I have taken a crack at making a dark-mode for scribble that is enacted with a media-query fir prefers-color-scheme: dark per this issue: https://github.com/racket/scribble/issues/285

Here are some screenshots (in the real version the sidebar stays constant):

![Screenshot 2024-10-26 at 20-59-38 4 10 Pairs and Lists](https://github.com/user-attachments/assets/b6e2970e-88a5-4707-a4ac-6ca442426dab)
