### PR TITLE
Update URL query param upon completed searches

### DIFF
--- a/scribble-lib/scribble/scribble-common.js
+++ b/scribble-lib/scribble/scribble-common.js
@@ -15,7 +15,7 @@ function GetPageQueryString() {
 }
 
 function GetPageArg(key, def) {
-  return GetURL().searchParams.get(key) || def;
+  return GetPageArgs().get(key) || def;
 }
 
 function MergePageArgsIntoLink(a) {

--- a/scribble-lib/scribble/scribble-common.js
+++ b/scribble-lib/scribble/scribble-common.js
@@ -2,21 +2,30 @@
 
 // Page Parameters ------------------------------------------------------------
 
-var page_query_string = location.search.substring(1);
-const page_args = new URLSearchParams(location.search);
+function GetURL() {
+  return new URL(location);
+}
+
+function GetPageArgs() {
+  return GetURL().searchParams;
+}
+
+function GetPageQueryString() {
+  return GetPageArgs().toString();
+}
 
 function GetPageArg(key, def) {
-  return page_args.get(key) || def;
+  return GetURL().searchParams.get(key) || def;
 }
 
 function MergePageArgsIntoLink(a) {
-  if (page_args.size === 0 || !a.dataset.pltdoc) return;
+  if (GetPageArgs().size === 0 || !a.dataset.pltdoc) return;
   a.href = MergePageArgsIntoUrl(a.href);
 }
 
 function MergePageArgsIntoUrl(href) {
   const url = new URL(href, window.location.href);
-  for (const [key, val] of page_args) {
+  for (const [key, val] of GetPageArgs()) {
     if (url.searchParams.has(key)) continue;
     url.searchParams.append(key, val)
   }


### PR DESCRIPTION
Fixes #454. The other half of this PR is at https://github.com/racket/racket/pull/5095.

This PR specifically removes `page_query_string` and `page_args`, which updates on each page refresh, and is in favor of `GetPageQueryString` and `GetPageArgs` function calls to fetch the current URL and its params.