### PR TITLE
fixed some typos in the doc

### DIFF
--- a/scribble-doc/scribblings/scribble/core.scrbl
+++ b/scribble-doc/scribblings/scribble/core.scrbl
@@ -1248,7 +1248,7 @@ reverse order):
        which is shown as part of the combined section number only when
        it's the first element.}
 
- @item{A a list corresponds to a @tech{numberer}-generated section
+ @item{A list corresponds to a @tech{numberer}-generated section
        string plus its separator string, where the separator is used
        in a combined section number after the section string and
        before a subsection's number (or, for some output modes, before

--- a/scribble-doc/scribblings/scribble/renderer.scrbl
+++ b/scribble-doc/scribblings/scribble/renderer.scrbl
@@ -180,7 +180,7 @@ is a result from the @method[render<%> collect] method.}
            list?]{
 
 Produces the final output.  The @racket[ri] argument is a result from
-the @method[render<%> render] method.
+the @method[render<%> resolve] method.
 
 The @racket[dests] provide names of files for Latex or single-file
 HTML output, or names of sub-directories for multi-file HTML output.


### PR DESCRIPTION
When I read the documentation, I found two typos.