### PR TITLE
Update scribble.tex

### DIFF
--- a/scribble-lib/scribble/scribble.tex
+++ b/scribble-lib/scribble/scribble.tex
@@ -297,7 +297,7 @@
 % The \refpara command corresponds to `margin-note'. The
 % refcolumn and refcontent environments also wrap the note,
 % because they simplify the CSS side.
-\newcommand{\refpara}[1]{\normalmarginpar\marginpar{\raggedright \footnotesize #1}}
+\newcommand{\refpara}[1]{\footnote{ #1}}
 \newcommand{\refelem}[1]{\refpara{#1}}
 \newenvironment{refcolumn}{}{}
 \newenvironment{refcontent}{}{}


### PR DESCRIPTION
change to \footnote{} because identifiers are too long and long identifier are not handled well by \marginpar{} - causing prints to fail to be printable due to exceeding the printable area of the page