### PR TITLE
Latex/PDF: use plain text for PDF table of content

### DIFF
--- a/scribble-lib/scribble/latex-render.rkt
+++ b/scribble-lib/scribble/latex-render.rkt
@@ -226,7 +226,12 @@
                          (depth . > . 1)
                          (not no-number?))
                 (printf "~a\\quad{}" (car (format-number number null)))))
-            (printf "\n\n\\~a~a~a"
+            (printf "\n\n")
+            (unless no-toc?
+              (printf "\\nextTitlePlain{")
+              (render-content (content->string (part-title-content d)) d ri)
+              (printf "}"))
+            (printf "\\~a~a~a"
                     (case depth
                       [(0 1) (if grouper?
                                  "partNewpage\n\n\\Spart"

--- a/scribble-lib/scribble/scribble.tex
+++ b/scribble-lib/scribble/scribble.tex
@@ -325,11 +325,14 @@
 \let\SOriginalthesubsection\thesubsection
 \let\SOriginalthesubsubsection\thesubsubsection
 
+\newcommand{\nextTitlePlain}[1]{\def\theNextTitlePlain{#1}}
+\newcommand{\useNextTitlePlain}[1]{\texorpdfstring{#1}{\theNextTitlePlain}}
+
 % sections
-\newcommand{\Spart}[2]{\part[#1]{#2}}
-\newcommand{\Ssection}[2]{\section[#1]{#2}\let\thesubsection\SOriginalthesubsection}
-\newcommand{\Ssubsection}[2]{\subsection[#1]{#2}\let\thesubsubsection\SOriginalthesubsubsection}
-\newcommand{\Ssubsubsection}[2]{\subsubsection[#1]{#2}}
+\newcommand{\Spart}[2]{\part[\useNextTitlePlain{#1}]{#2}}
+\newcommand{\Ssection}[2]{\section[\useNextTitlePlain{#1}]{#2}\let\thesubsection\SOriginalthesubsection}
+\newcommand{\Ssubsection}[2]{\subsection[\useNextTitlePlain{#1}]{#2}\let\thesubsubsection\SOriginalthesubsubsection}
+\newcommand{\Ssubsubsection}[2]{\subsubsection[\useNextTitlePlain{#1}]{#2}}
 \newcommand{\Ssubsubsubsection}[2]{{\bf #2}}
 \newcommand{\Ssubsubsubsubsection}[2]{\Ssubsubsubsection{#1}{#2}}
 
@@ -342,10 +345,10 @@
 \newcommand{\Ssubsubsubsubsectionstar}[1]{\Ssubsubsubsectionstar{#1}}
 
 % "starx" means unnumbered but in ToC:
-\newcommand{\Spartstarx}[2]{\Spartstar{#2}\phantomsection\addcontentsline{toc}{part}{#1}}
-\newcommand{\Ssectionstarx}[2]{\Ssectionstar{#2}\phantomsection\addcontentsline{toc}{section}{#1}}
-\newcommand{\Ssubsectionstarx}[2]{\Ssubsectionstar{#2}\phantomsection\addcontentsline{toc}{subsection}{#1}}
-\newcommand{\Ssubsubsectionstarx}[2]{\Ssubsubsectionstar{#2}\phantomsection\addcontentsline{toc}{subsubsection}{#1}}
+\newcommand{\Spartstarx}[2]{\Spartstar{#2}\phantomsection\addcontentsline{toc}{part}{\useNextTitlePlain{#1}}}
+\newcommand{\Ssectionstarx}[2]{\Ssectionstar{#2}\phantomsection\addcontentsline{toc}{section}{\useNextTitlePlain{#1}}}
+\newcommand{\Ssubsectionstarx}[2]{\Ssubsectionstar{#2}\phantomsection\addcontentsline{toc}{subsection}{\useNextTitlePlain{#1}}}
+\newcommand{\Ssubsubsectionstarx}[2]{\Ssubsubsectionstar{#2}\phantomsection\addcontentsline{toc}{subsubsection}{\useNextTitlePlain{#1}}}
 \newcommand{\Ssubsubsubsectionstarx}[2]{\Ssubsubsubsectionstar{#2}}
 \newcommand{\Ssubsubsubsubsectionstarx}[2]{\Ssubsubsubsubsectionstar{#2}}
 


### PR DESCRIPTION
This is an attempt to fix #484. It seems to work on machine machine and doesn't break other documents that I tried, but I'm not very confident about LaTeX-related changes, though.