### PR TITLE
WIP: add option to output xexpr of html

### DIFF
--- a/scribble-lib/scribble/base-render.rkt
+++ b/scribble-lib/scribble/base-render.rkt
@@ -57,7 +57,8 @@
                 [extra-files null]
                 [image-preferences null]
                 [helper-file-prefix #f]
-                [keep-existing-helper-files? #f])
+                [keep-existing-helper-files? #f]
+                [xexpr-out? #f])
 
     (define/public (current-render-mode)
       '())

--- a/scribble-lib/scribble/html-render.rkt
+++ b/scribble-lib/scribble/html-render.rkt
@@ -10,6 +10,7 @@
          racket/port
          racket/list
          racket/string
+         racket/trace
          file/convertible
          mzlib/runtime-path
          setup/main-doc
@@ -22,11 +23,22 @@
          racket/draw/gif
          pkg/path
          (prefix-in xml: xml/xml)
+         fmt
          (for-syntax racket/base)
          "search.rkt"
          (except-in "base.rkt" url))
 (provide render-mixin
          render-multi-mixin)
+
+(struct scribble-xexpr-page
+  (title     ; string?
+   author    ; string?
+   date      ; string? - 8601 datetime format
+   version   ; string? version number
+   tags      ; (listof string?)
+   tocset    ; (list?)
+   article   ; xexpr?
+   ) #:prefab)
 
 (define (number->decimal-string s)
   (number->string (if (integer? s) s (exact->inexact s))))
@@ -273,9 +285,10 @@
              extract-part-style-files
              extract-version
              extract-authors
+             extract-date
              extract-pretitle
              link-render-style-at-element)
-    (inherit-field prefix-file style-file style-extra-files image-preferences)
+    (inherit-field prefix-file style-file style-extra-files image-preferences xexpr-out?)
 
     (init-field [alt-paths null]
                 ;; `up-path' is either a link "up", or #t which goes
@@ -290,7 +303,10 @@
     (define/override (current-render-mode)
       '(html))
 
-    (define/override (get-suffix) #".html")
+    (define/override (get-suffix)
+      (if xexpr-out?
+          #".rktd"
+          #".html"))
 
     (define/override (index-manual-newlines?)
       #t)
@@ -564,6 +580,102 @@
     (define/public (render-top ds fns ri)
       (super render ds fns ri))
 
+    (define/public (list-of-toc-view d ri)
+      (define has-sub-parts?
+        (pair? (part-parts d)))
+      (define sub-parts-on-other-page?
+        (and has-sub-parts?
+             (part-whole-page? (car (part-parts d)) ri)))
+      (define toc-chain
+        (let loop ([d d] [r (if has-sub-parts? (list d) '())])
+          (cond [(collected-info-parent (part-collected-info d ri))
+                 => (lambda (p) (loop p (cons p r)))]
+                [(pair? r) r]
+                ;; we have no toc, so use just the current part
+                [else (list d)])))
+      (define top (car toc-chain))
+      (define (toc-item->title+num t show-mine?)
+        (values
+         (dest->url (resolve-get t ri (car (part-tags/nonempty t))))
+         (if (or (eq? t d) (and show-mine? (memq t toc-chain)))
+             "tocviewselflink"
+             "tocviewlink")
+         (render-content (strip-aux (or (part-title-content t) '("???"))) d ri)
+         (format-number (collected-info-number (part-collected-info t ri))
+                        null)))
+      (define (toc-item->block t i)
+        (define-values (url linktype title num) (toc-item->title+num t #f))
+        (define children  ; note: might be empty
+          (filter (lambda (p) (not (part-style? p 'toc-hidden)))
+                  (part-parts t)))
+        (define id (format "tocview_~a" i))
+        (define last? (eq? t (last toc-chain)))
+        (define expand? (or (and last? 
+                                 (or (not has-sub-parts?)
+                                     sub-parts-on-other-page?))
+                            (and has-sub-parts?
+                                 (not sub-parts-on-other-page?)
+                                 ;; next-to-last?
+                                 (let loop ([l toc-chain])
+                                   (cond
+                                    [(null? l) #f]
+                                    [(eq? t (car l))
+                                     (and (pair? (cdr l)) (null? (cddr l)))]
+                                    [else (loop (cdr l))])))))
+        (define top? (eq? t top))
+        (define header (list num title))
+        (list
+         (if top?
+             "tocviewlist tocviewlisttopspace"
+             "tocviewlist")
+         (if top? (list  "tocviewtitle" header) header)
+         (if (null? children)
+             ""
+             (list (list
+                    (cond
+                      [(and top? last?) "tocviewsublistonly"]
+                      [top? "tocviewsublisttop"]
+                      [last? "tocviewsublistbottom"]
+                      [else "tocviewsublist"])
+                    (if expand? 'block 'none)
+                    id)
+                   (for/list ([c children])
+                     (let-values ([(u l t n) (toc-item->title+num c #t)])
+                       (list n u l t)))))))
+      (define (toc-content)
+        ;; no links -- the code constructs links where needed
+        (parameterize ([current-no-links #t]
+                       [extra-breaking? #t])
+          (for/list ([t toc-chain] [i (in-naturals)])
+            (toc-item->block t i))))
+      (list
+       "tocset"
+       (if (part-style? d 'no-toc)
+              null
+              ;; toc-wrap determines if we get the toc or just the title !!!
+              (toc-content))
+          (if (part-style? d 'no-sidebar)
+                null
+                (list-of-onthispage-contents
+                 d ri top (if (part-style? d 'no-toc) "tocview" "tocsub")
+                 sub-parts-on-other-page?))
+          (parameterize ([extra-breaking? #t])
+              (append-map (lambda (e)
+                            (let loop ([e e])
+                              (cond
+                               [(and (table? e)
+                                     (memq 'aux (style-properties (table-style e)))
+                                     (pair? (table-blockss e)))
+                                (render-table e d ri #f)]
+                               [(delayed-block? e)
+                                (loop (delayed-block-blocks e ri))]
+                               [(traverse-block? e)
+                                (loop (traverse-block-block e ri))]
+                               [(compound-paragraph? e)
+                                (append-map loop (compound-paragraph-blocks e))]
+                               [else null])))
+                          (part-blocks d)))))
+
     (define/public (render-toc-view d ri)
       (define has-sub-parts?
         (pair? (part-parts d)))
@@ -687,6 +799,115 @@
                                           (part-parts p))))
                   (hash-set! hidden-memo p h?)
                   h?)))
+
+    (define/private (list-of-onthispage-contents d ri top box-class sections-in-toc?)
+        (let ([nearly-top? (lambda (d) 
+                             ;; If ToC would be collapsed, then 
+                             ;; no section is nearly the top
+                             (if (not sections-in-toc?)
+                                 #f
+                                 (nearly-top? d ri top)))])
+          (define (flow-targets flow)
+            (append-map block-targets flow))
+          (define (block-targets e)
+            (cond [(table? e) (table-targets e)]
+                  [(paragraph? e) (para-targets e)]
+                  [(itemization? e)
+                   (append-map flow-targets (itemization-blockss e))]
+                  [(nested-flow? e)
+                   (append-map block-targets (nested-flow-blocks e))]
+                  [(compound-paragraph? e)
+                   (append-map block-targets (compound-paragraph-blocks e))]
+                  [(delayed-block? e) null]
+                  [(traverse-block? e) (block-targets (traverse-block-block e ri))]))
+          (define (para-targets para)
+            (let loop ([a (paragraph-content para)])
+              (cond
+                [(list? a) (append-map loop a)]
+                [(toc-target-element? a) (list a)]
+                [(toc-element? a) (list a)]
+                [(element? a) (loop (element-content a))]
+                [(delayed-element? a) (loop (delayed-element-content a ri))]
+                [(traverse-element? a) (loop (traverse-element-content a ri))]
+                [(part-relative-element? a) (loop (part-relative-element-content a ri))]
+                [else null])))
+          (define  (table-targets table)
+            (append-map
+             (lambda (blocks)
+               (append-map (lambda (f) (if (eq? f 'cont) null (block-targets f)))
+                           blocks))
+             (table-blockss table)))
+          (define ps
+            ((if (or (nearly-top? d) (eq? d top)) values (lambda (p) (if (pair? p) (cdr p) null)))
+             (let flatten ([d d] [prefixes null] [top? #t])
+               (let ([prefixes (if (and (not top?) (part-tag-prefix-string d))
+                                   (cons (part-tag-prefix-string d) prefixes)
+                                   prefixes)])
+                 (append*
+                  ;; don't include the section if it's in the TOC
+                  (if (or (nearly-top? d) 
+                          (part-style? d 'toc-hidden))
+                      null 
+                      (list (vector d prefixes d)))
+                  ;; get internal targets:
+                  (map (lambda (v) (vector v prefixes d)) (append-map block-targets (part-blocks d)))
+                  (map (lambda (p) (if (or (part-whole-page? p ri) 
+                                           (and (part-style? p 'toc-hidden)
+                                                (all-toc-hidden? p)))
+                                       null
+                                       (flatten p prefixes #f)))
+                       (part-parts d)))))))
+          (define any-parts? (ormap (compose part? (lambda (p) (vector-ref p 0))) ps))
+          (if (null? ps)
+              null
+              (list
+               (get-onthispage-label)
+               "tocsublist"
+               (map (lambda (p)
+                      (let ([p (vector-ref p 0)]
+                            [prefixes (vector-ref p 1)]
+                            [from-d (vector-ref p 2)]
+                            [add-tag-prefixes
+                             (lambda (t prefixes)
+                               (if (null? prefixes)
+                                   t
+                                   (cons (car t) (append prefixes (cdr t)))))])
+                        (list
+                         (if (part? p)
+                             (format-number
+                              (collected-info-number
+                               (part-collected-info p ri))
+                              null)
+                             null)
+                         (if (toc-element? p)
+                             (render-content (toc-element-toc-content p)
+                                             from-d ri)
+                             (parameterize ([current-no-links #t]
+                                            [extra-breaking? #t])
+                               (list 
+                                (uri-unreserved-encode
+                                 (anchor-name
+                                  (add-tag-prefixes
+                                   (tag-key (if (part? p)
+                                                (car (part-tags/nonempty p))
+                                                (target-element-tag p))
+                                            ri)
+                                   prefixes)))
+                                (cond
+                                  [(part? p) "tocsubseclink"]
+                                  [any-parts? "tocsubnonseclink"]
+                                  [else "tocsublink"])
+                                        
+                                (render-content
+                                 (if (part? p)
+                                     (strip-aux
+                                      (or (part-title-content p)
+                                          "???"))
+                                     (if (toc-target2-element? p)
+                                         (toc-target2-element-toc-content p)
+                                         (element-content p)))
+                                 from-d ri)))))))
+                    ps)))))
 
     (define/private (render-onthispage-contents d ri top box-class sections-in-toc?)
         (let ([nearly-top? (lambda (d) 
@@ -846,6 +1067,10 @@
                                   `(title ,@(format-number number '(nbsp))
                                           ,(content->string (strip-aux c) this d ri)))]
                             [else `(title)])]
+               [title-string (cond [(part-title-content d)
+                             => (lambda (c)
+                                  (content->string (strip-aux c) this d ri))]
+                            [else null])]
                [dir-depth (part-nesting-depth d ri)]
                [extract (lambda (pred get) (extract-part-style-files 
                                             d
@@ -863,16 +1088,16 @@
           (define script-file-path
             (or (lookup-path script-file alt-paths) 
                 (install-file/as-url script-file)))
-          (if (bytes? prefix-file)
+          (unless  xexpr-out?
+            (if (bytes? prefix-file)
               (display prefix-file)
               (call-with-input-file*
                prefix-file
                (lambda (in)
-                 (copy-port in (current-output-port)))))
+                 (copy-port in (current-output-port))))))
           (parameterize ([xml:empty-tag-shorthand xml:html-empty-tags])
-            (xml:write-xexpr
-              `(html ,(style->attribs (part-style d))
-                 (head ()
+            (define head-xexpr
+                 `(head ()
                    (meta ([http-equiv "content-type"]
                           [content "text/html; charset=utf-8"]))
                    (meta ([name "viewport"]
@@ -908,20 +1133,52 @@
                    ,@(extract head-addition? head-addition-xexpr)
                    ,@(for/list ([p (style-properties (part-style d))]
                                 #:when (head-extra? p))
-                       (head-extra-xexpr p)))
-                 (body ([id ,(or (extract-part-body-id d ri)
-                                 "scribble-racket-lang-org")])
-                   ,@(if (part-style? d 'no-toc+aux)
-                         null
-                         (render-toc-view d ri))
-                   (div ([class "maincolumn"])
+                       (head-extra-xexpr p))))
+            (define content-xexpr (render-part d ri))
+            (define main-xexpr
+                   `(div ([class "maincolumn"])
                      (div ([class "main"])
                        ,@(parameterize ([current-version (extract-version d)])
                            (render-version d ri))
                        ,@(navigation d ri #t)
-                       ,@(render-part d ri)
-                       ,@(navigation d ri #f)))
-                   (div ([id "contextindicator"]) nbsp))))))))
+                       ,@content-xexpr
+                       ,@(navigation d ri #f))))
+            (define body-xexpr
+                 `(body ([id ,(or (extract-part-body-id d ri)
+                                 "scribble-racket-lang-org")])
+                   ,@(if (part-style? d 'no-toc+aux)
+                         null
+                         (render-toc-view d ri))
+                   ,main-xexpr
+                   (div ([id "contextindicator"]) nbsp)))
+            (define part-xexpr
+              `(html ,(style->attribs (part-style d))
+                     ,head-xexpr
+                     ,body-xexpr))
+            (define article-xexpr
+                   `(article ([class "document"])
+                       ,@content-xexpr))
+            (define (authors-list)
+              (define authors-paragraph-list (extract-authors d))
+              (for/list ([p authors-paragraph-list])
+                (car (paragraph-content p))))
+            (if xexpr-out?
+                (let ([article
+                       (scribble-xexpr-page
+                        title-string        ; title
+                        (authors-list)      ; authors
+                        (extract-date d)    ; date
+                        (extract-version d) ; document version
+                        null                ; tags
+                        (unless (part-style? d 'no-toc+aux)
+                         (list-of-toc-view d ri)) ; tocset
+                        article-xexpr       ; article
+                        )]
+                      [article-string (open-output-string)])
+                  (begin
+                    (write article article-string)
+                    (displayln (program-format (get-output-string article-string) #:width 72))))
+                (xml:write-xexpr part-xexpr))))))
 
     (define (toc-part? d ri)
       (and (part-style? d 'toc)
@@ -1190,13 +1447,13 @@
                                            [class "heading-anchor"]
                                            [title "Link to here"])
                                           "🔗"))])
-                           ,@(if (and src taglet)
-                                 (list '(a ([class "heading-source"]
-                                            [title "Internal Scribble link and Scribble source"]) "ℹ"))
-                                 '())
-                           ;; this is a dummy node so that the line height of heading-anchor
-                           ;; and heading-source are correct (even when their font size is not 100%)
-                           (span ([style "visibility: hidden"]) " "))))])
+                             ,@(if (and src taglet)
+                                   (list '(a ([class "heading-source"]
+                                              [title "Internal Scribble link and Scribble source"]) "ℹ"))
+                                   '())
+                             ;; this is a dummy node so that the line height of heading-anchor
+                             ;; and heading-source are correct (even when their font size is not 100%)
+                             (span ([style "visibility: hidden"]) " "))))])
              ,@(let ([auths (extract-authors d)])
                  (if (null? auths)
                      null

--- a/scribble-lib/scribble/render.rkt
+++ b/scribble-lib/scribble/render.rkt
@@ -26,7 +26,8 @@
                                          #:info-in-files (listof path-string?)
                                          #:info-out-file (or/c #f path-string?)
                                          #:quiet? any/c
-                                         #:warn-undefined? any/c)
+                                         #:warn-undefined? any/c
+                                         #:xexpr-out? any/c)
                          . ->* .
                          void?)]))
 
@@ -48,7 +49,8 @@
                 #:info-in-files [info-input-files null]
                 #:info-out-file [info-output-file #f]
                 #:quiet? [quiet? #t]
-                #:warn-undefined? [warn-undefined? (not quiet?)])
+                #:warn-undefined? [warn-undefined? (not quiet?)]
+                #:xexpr-out? [xexpr-out? #f])
   (when dest-dir (make-directory* dest-dir))
   (define renderer
     (new (render-mixin render%)
@@ -58,6 +60,7 @@
          [style-extra-files style-extra-files]
          [extra-files extra-files]
          [image-preferences image-preferences]
+         [xexpr-out? xexpr-out?]
          [helper-file-prefix helper-file-prefix]
          [keep-existing-helper-files? keep-existing-helper-files?]))
   (when redirect

--- a/scribble-lib/scribble/run.rkt
+++ b/scribble-lib/scribble/run.rkt
@@ -17,6 +17,7 @@
 
 (define current-render-mixin       (make-parameter html:render-mixin))
 (define current-html               (make-parameter #t))
+(define current-xexpr              (make-parameter #f))
 (define current-dest-directory     (make-parameter #f))
 (define current-dest-name          (make-parameter #f))
 (define current-info-output-file   (make-parameter #f))
@@ -93,6 +94,8 @@
     (current-html #f)
     (current-render-mixin markdown:render-mixin)]
    #:once-each
+   [("--xexpr") "generate xexpr body and navigation output instead of html output"
+    (current-xexpr #t)]
    [("--lib" "-l") "treat argument <file>s as library paths instead of filesystem paths"
     (current-lib-mode #t)]
    [("--dest") dir "write output in <dir>"
@@ -219,6 +222,7 @@
                          'scribble "result from `~s' of `~s' is not an xref: ~e"
                          (cdr mod+id) (car mod+id) xr))
                       xr))
-          #:info-out-file (current-info-output-file)))
+          #:info-out-file (current-info-output-file)
+          #:xexpr-out? (current-xexpr)))
 
 (run)


### PR DESCRIPTION
Output the body as an xexpr, and provide various metadata, including TOC links, in a struct rather than in html.

I've refactored `html-render.rkt` to optionally output the body of the document as an `xexpr` rather than as html, and provide document metadata including the TOC links in a struct rather than in html. My goal is to allow use of scribble's html in something like Greg Hendershott's Tadpole, and so I want to provide the document content in a form that can be applied to an html template or xexpr template. I also want to provide the TOC links in a form that can be rendered by site templates using pure CSS to provide a responsive view of the navigation links.

I'm submitting this pull request to gather some feedback on my approach, before committing to doing more work to make this something actually mergeable into Scribble. To pull out the TOC as data rather than as html, I've duplicated a lot of code from the `render-toc-view` and `render-onthispage-contents` methods. A finished pull request would refactor `render-toc-view` and `render-onthispage-contents` to use the output of my `list-of-toc-view` and `list-of-onthispage-contents`. I'm also not sure at this point how I want to represent the TOC contents. Using structs would probably be better than the current hacked nested lists.

Is this a feature the Racket developers would consider including in Scribble? Except for the duplicated code, does my implementation approach look reasonable?