### PR TITLE
add 'bare-anchors style property

### DIFF
--- a/scribble-doc/scribblings/scribble/core.scrbl
+++ b/scribble-doc/scribblings/scribble/core.scrbl
@@ -488,6 +488,9 @@ The recognized @tech{style properties} are as follows:
        to skip the generation of an entry for the part's title in the
        document index.}
 
+ @item{@racket['bare-anchors] --- For HTML, omits the ``Link to here''
+   hidden hover link on title and section headers.}
+
  @item{@racket[document-version] structure --- A version number for
        this part and its sub-parts (except as overridden). When it is
        not @racket[""] may be used when rendering a document; at a

--- a/scribble-lib/scribble/html-render.rkt
+++ b/scribble-lib/scribble/html-render.rkt
@@ -112,6 +112,7 @@
 (define current-version (make-parameter (version)))
 (define current-part-files (make-parameter #f))
 (define current-render-convertible-requests (make-parameter '(png@2x-bytes png-bytes svg-bytes gif-bytes)))
+(define bare-anchors? (make-parameter #f)) ;; don't decorate anchors with "link-to-here" hovers
 
 (define (url->string* u)
   (parameterize ([current-url-encode-mode 'unreserved])
@@ -820,7 +821,8 @@
       0)
 
     (define/public (render-one-part d ri fn number)
-      (parameterize ([current-output-file fn])
+      (parameterize ([current-output-file fn]
+                     [bare-anchors? (part-style? d 'bare-anchors)])
         (let* ([defaults (let loop ([d d])
                            (or (ormap (lambda (v) (and (html-defaults? v) v))
                                       (style-properties (part-style d)))
@@ -1180,23 +1182,27 @@
                      ,@(if (part-title-content d)
                            (render-content (part-title-content d) d ri)
                            null)
-                     (span ([class "button-group"])
-                           ,@(match (part-tags d)
-                               ['() '()]
-                               [(cons t _)
-                                (list `(a ([href ,(format "#~a" (anchor-name
-                                                                 (add-current-tag-prefix
-                                                                  (tag-key t ri))))]
-                                           [class "heading-anchor"]
-                                           [title "Link to here"])
-                                          "🔗"))])
-                           ,@(if (and src taglet)
-                                 (list '(a ([class "heading-source"]
-                                            [title "Internal Scribble link and Scribble source"]) "ℹ"))
-                                 '())
-                           ;; this is a dummy node so that the line height of heading-anchor
-                           ;; and heading-source are correct (even when their font size is not 100%)
-                           (span ([style "visibility: hidden"]) " "))))])
+                     ,@(if (bare-anchors?)
+                           null
+                           `((span ([class "button-group"])
+                                   ,@(match (part-tags d)
+                                       ['() '()]
+                                       [(cons t _)
+                                        (list `(a ([href ,(format "#~a" (anchor-name
+                                                                         (add-current-tag-prefix
+                                                                          (tag-key t ri))))]
+                                                   [class "heading-anchor"]
+                                                   [title "Link to here"])
+                                                  "🔗"))])
+                                   ,@(if (and src taglet)
+                                         (list '(a ([class "heading-source"]
+                                                    [title "Internal Scribble link and Scribble source"]) "ℹ"))
+                                         '())
+                                   ;; this is a dummy node so that the line height of heading-anchor
+                                   ;; and heading-source are correct (even when their font size is not 100%)
+                                   (span ([style "visibility: hidden"]) " ")))
+                           )
+                     ))])
              ,@(let ([auths (extract-authors d)])
                  (if (null? auths)
                      null


### PR DESCRIPTION
Add a `'bare-anchors` style property that causes the html renderer to omit the "Link to here" hover links on titles and section headers. This just leaves the bare anchor tag, without the "Link to here" decoration. 

This change removes the need for CSS to hide the link and disclose it only during a mouser hover. A user can still obtain a link to the title or section from the Table of Contents sidebar.

This change facilitates the use of Scribble html output in contexts other than Racket documentation. 