### PR TITLE
replace use of html tt with span of class 'stt'

### DIFF
--- a/scribble-lib/scribble/html-render.rkt
+++ b/scribble-lib/scribble/html-render.rkt
@@ -767,7 +767,7 @@
                                               ,@(format-number
                                                  (collected-info-number
                                                   (part-collected-info p ri))
-                                                 '((tt nbsp)))))
+                                                 '((span ([class "stt"]) nbsp)))))
                                       '(""))
                                 ,@(if (toc-element? p)
                                       (render-content (toc-element-toc-content p)
@@ -1173,7 +1173,7 @@
                            '())
                        (list '[class "heading"])
                        (style->attribs (part-style d)))
-                     ,@(format-number number '((tt nbsp)))
+                     ,@(format-number number '((span ([class "stt"]) nbsp)))
                      ,@(map (lambda (t)
                               `(a ([name ,(format "~a" (anchor-name (add-current-tag-prefix (tag-key t ri))))])))
                             (part-tags d))


### PR DESCRIPTION
HTML5 has deprecated the 'tt' tag. This commit replaces it with a span of class 'stt'. Note that the Scribble @tt function has already been fixed to use a span of class 'tt''. These two remaining uses are styling the nbsp separator between the section heading number and the section heading text. One use is in the tocsub link for the section, and the other is in the section heading itself.