### PR TITLE
replace SAuthorList span with div

### DIFF
--- a/scribble-lib/scribble/html-render.rkt
+++ b/scribble-lib/scribble/html-render.rkt
@@ -1201,7 +1201,7 @@
                  (if (null? auths)
                      null
                      `((div ([class "SAuthorListBox"])
-                            (span ([class "SAuthorList"])
+                            (div ([class "SAuthorList"])
                                   ,@(apply
                                      append
                                      (for/list ([auth (in-list auths)]


### PR DESCRIPTION
Each author is a paragraph. Block elements are not allowed within an inline element. Change the span to a div.