### PR TITLE
Enclose scribble parts in an html section tag

### DIFF
--- a/scribble-lib/scribble/html-render.rkt
+++ b/scribble-lib/scribble/html-render.rkt
@@ -1128,7 +1128,12 @@
             [else l]))
         (let ([number (collected-info-number (part-collected-info d ri))])
           (add-title-and-content-wrapper
-           `(,@(let ([pres (extract-pretitle d)])
+           `((section ([class ,(format "SsectionLevel~a" (number-depth number))]
+                       [id ,(format "section ~a"
+                                    (if (null? number)
+                                        "0"
+                                        (car (format-number number ""))))])
+             ,@(let ([pres (extract-pretitle d)])
                  (append-map (lambda (pre)
                                (do-render-paragraph pre d ri #f #t))
                              pres))
@@ -1216,7 +1221,7 @@
                  (if (null? secs)
                      null
                      (append (render-part (car secs) ri)
-                             (loop (add1 pos) (cdr secs))))))))))
+                             (loop (add1 pos) (cdr secs)))))))))))
 
     (define/private (render-flow* p part ri starting-item? special-last?)
       ;; Wrap each table with <p>, except for a trailing table


### PR DESCRIPTION
Enhance the Scribble html renderer to enclose the `@title`, `@section`, `@subsection`, etc parts in an html <section> tag. This enables better support for assistive technologies, and some CSS layout strategies such as a "block-based" design. For the latter, see Shriram Krishnamurthi's thread on the Racket Discord.

The section tag `class` attribute is set to the level of the part in the of `SsectionLevel<n>`, and the `id` attribute is set to `section <the section number>`. The `id` attribute is necessary for "block-based" design.

