### PR TITLE
Update scribble-prefix.html for modern standards

### DIFF
--- a/scribble-lib/scribble/scribble-prefix.html
+++ b/scribble-lib/scribble/scribble-prefix.html
@@ -1,1 +1,1 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>


### PR DESCRIPTION
The dtd spec is a hold over from long retired standards; moreover scribble renders HTML that doesn't adhere to the dtd specified here (e.g. <section>).  This change follows the HTML "Living Standard": https://html.spec.whatwg.org/multipage/syntax.html#syntax-doctype