### PR TITLE
Error using #:auto-value of number

### DIFF
--- a/scribble-lib/scribble/racket.rkt
+++ b/scribble-lib/scribble/racket.rkt
@@ -280,8 +280,9 @@
          [(and (number? sc)
                (inexact? sc))
           (define s (iformat "~s" sc))
-          (if (= (string-length s)
-                 (- (syntax-span c) 2))
+          (if (let ([span (syntax-span c)])
+                (and span (= (string-length s)
+                             (- span 2))))
               ;; There's no way to know whether the source used #i,
               ;; but it should be ok to include it:
               (string-append "#i" s)

--- a/scribble-test/tests/scribble/docs/manual-ex.rkt
+++ b/scribble-test/tests/scribble/docs/manual-ex.rkt
@@ -31,3 +31,4 @@
 (define val:list '(1 2 3 4))
 (define val:vector #(1 2 3 4))
 (define val:param (make-parameter 'foo))
+(define val:flonum 1.25)

--- a/scribble-test/tests/scribble/docs/manual.scrbl
+++ b/scribble-test/tests/scribble/docs/manual.scrbl
@@ -80,6 +80,7 @@ A function, again, not a link target, documented to return @racket[10] using a d
 @defthing[#:link-target? #f val:kw any/c #:auto-value]{Test auto-value keyword reading.}
 @defthing[#:link-target? #f val:list any/c #:auto-value]{Test auto-value list reading.}
 @defthing[#:link-target? #f val:vector any/c #:auto-value]{Test auto-value vector reading.}
+@defthing[#:link-target? #f val:flonum any/c #:auto-value]{Test auto-value flonum reading.}
 
 @defstruct[pt ([x real?] [y real?])]{A structure type with extra name.}
 

--- a/scribble-test/tests/scribble/docs/manual.txt
+++ b/scribble-test/tests/scribble/docs/manual.txt
@@ -186,6 +186,10 @@ val:vector : any/c = #(1 2 3 4)
 
 Test auto-value vector reading.
 
+val:flonum : any/c = 1.25
+
+Test auto-value flonum reading.
+
 (struct pt (x y)                     
     #:extra-constructor-name make-pt)
   x : real?                          


### PR DESCRIPTION
Make sure that `syntax-span` is not false before checking length

currently rendering scribble with an auto-value (or using #:value with other syntax objects that are numbers) fails.
This fixes the direct problem for me, but I'm not sure it's the best approach.

Example:
```
#lang scribble/manual

@(module a racket/base
   (provide :a :b)
   (define :a 4.8)
   (define :b 'symbol))

@(require (for-label (submod "." a)))

@defthing[:b symbol? #:auto-value]
@defthing[:a number? #:value 3.5]
@defthing[:a number? #:auto-value] @;; this fails
```
tested using "Welcome to DrRacket, version 9.1.0.11 [cs]." on windows