### PR TITLE
fix condition for single-collection package in "manual-racket.js"

### DIFF
--- a/scribble-lib/scribble/manual-racket.js
+++ b/scribble-lib/scribble/manual-racket.js
@@ -109,8 +109,8 @@ var prefixes = { "github.com": "tree",
 
 
 function AddSourceUrl(source, mod_path, collection, info) {
-    // multi is encoded as an array, empty as false
-    single_collection = (typeof collection === "string");
+    // multi is encoded as an array, single is either false or a string
+    single_collection = (collection === false || typeof collection === "string");
 
     var parsed = source && mod_path && ParseSource(source, mod_path, single_collection);
 


### PR DESCRIPTION
The condition should test for false as well, because single-collection package either has false or a string as the collection name.

Fix racket/racket#5519.