### PR TITLE
Render lsquo as a backtick in content->string

### DIFF
--- a/scribble-lib/scribble/core.rkt
+++ b/scribble-lib/scribble/core.rkt
@@ -698,6 +698,7 @@
                         [(mdash) "---"]
                         [(ndash) "--"]
                         [(ldquo rdquo) "\""]
+                        [(lsquo) "`"]
                         [(rsquo) "'"]
                         [(rarr) "->"]
                         [(lang) "<"]

--- a/scribble-test/tests/scribble/decode.rkt
+++ b/scribble-test/tests/scribble/decode.rkt
@@ -43,6 +43,7 @@
 (check-true (content? (decode-content '("x"))))
 (check-true (content? (decode-elements '("x"))))
 (check-true (content? (decode-string "x")))
+(check-equal? (content->string (decode-string "`")) "`")
 
 (check-true (whitespace? " \n\t\r"))
 (check-true (not (whitespace? " \n\t\rx ")))


### PR DESCRIPTION
`content->string` renders `lsquo` as the literal text `lsquo`. The HTML renderer uses `content->string` for document titles, which causes [the Racket Guide’s quasiquoting page](https://docs.racket-lang.org/guide/qq.html) to have `lsquo` in its title.

Map `lsquo` to a backtick, matching the existing `rsquo` mapping to an apostrophe. Add a regression test through `decode-string`.

Tests

- `raco setup --check-pkg-deps --pkgs scribble-text-lib scribble-html-lib scribble-lib scribble-doc scribble-test`
- `raco test --drdr --package scribble-text-lib scribble-html-lib scribble-lib scribble-doc scribble-test`