### PR TITLE
Render emphasis, subscripts, and superscripts as semantic HTML

### DIFF
--- a/scribble-lib/scribble/html-render.rkt
+++ b/scribble-lib/scribble/html-render.rkt
@@ -1672,6 +1672,13 @@
               (let ([s (content-style e)])
                 (and (style? s)
                      (style->tag s)))]
+             [semantic-tag
+              (and (symbol? name)
+                   (case name
+                     [(emph) 'em]
+                     [(superscript) 'sup]
+                     [(subscript) 'sub]
+                     [else #f]))]
              [resources (for/list ([p (in-list properties)]
                                    #:when (install-resource? p))
                           (install-resource-path p))]
@@ -1720,7 +1727,8 @@
                    (not link?)
                    (not anchor?)
                    (not newline?)
-                   (not alt-tag))
+                   (not alt-tag)
+                   (not semantic-tag))
               content
               `(,@(if anchor?
                       (append-map (lambda (v)
@@ -1733,6 +1741,7 @@
                    [alt-tag alt-tag]
                    [link? 'a]
                    [newline? 'br]
+                   [semantic-tag semantic-tag]
                    [else 'span]) 
                  ,(append
                    (if link-resource
@@ -1754,8 +1763,8 @@
            [(url) '([class "url"])]
            [(no-break) '([class "nobreak"])]
            [(sf) '([class "ssansserif"])]
-           [(superscript) '([style "vertical-align: super; font-size: 80%"])]
-           [(subscript) '([style "vertical-align: sub; font-size: 80%"])]
+           [(superscript) '([style "vertical-align: super; font-size: 80%; line-height: inherit"])]
+           [(subscript) '([style "vertical-align: sub; font-size: 80%; line-height: inherit"])]
            [(smaller) '([class "Smaller"])]
            [(larger) '([class "Larger"])]
            [(hspace) '([class "hspace"])]

--- a/scribble-test/tests/scribble/html-render.rkt
+++ b/scribble-test/tests/scribble/html-render.rkt
@@ -1,0 +1,63 @@
+#lang racket/base
+
+(require racket/class
+         rackunit
+         scribble/base
+         scribble/base-render
+         scribble/core
+         scribble/html-properties
+         (prefix-in html: scribble/html-render))
+
+(define renderer
+  (new (html:render-mixin render%)
+       [dest-dir (find-system-path 'temp-dir)]))
+
+(define (render-content content)
+  (send renderer render-content content #f #f))
+
+(test-case "semantic text styles"
+  (check-equal?
+   (render-content (emph "emphasized"))
+   '((em ((class "emph")) "emphasized")))
+
+  (check-equal?
+   (render-content (emph "outer " (emph "inner")))
+   '((em ((class "emph")) "outer "
+         (em ((class "emph")) "inner"))))
+
+  (check-equal?
+   (render-content
+    (elem #:style
+          (make-style 'emph
+                      (list (attributes '((data-test . "value")))))
+          "styled emphasis"))
+   '((em ((class "emph") (data-test "value")) "styled emphasis")))
+
+  (check-equal?
+   (render-content (superscript "superscript"))
+   '((sup ((style "vertical-align: super; font-size: 80%; line-height: inherit"))
+          "superscript")))
+
+  (check-equal?
+   (render-content (subscript "subscript"))
+   '((sub ((style "vertical-align: sub; font-size: 80%; line-height: inherit"))
+          "subscript")))
+
+  (check-equal?
+   (render-content
+    (elem #:style
+          (make-style 'emph (list (alt-tag "i")))
+          "alternate tag"))
+   '((i ((class "emph")) "alternate tag")))
+
+  (check-equal?
+   (render-content
+    (elem #:style
+          (make-style 'emph
+                      (list (target-url "https://example.com")))
+          "linked"))
+   '((a ((href "https://example.com") (class "emph")) "linked")))
+
+  (check-equal?
+   (render-content (elem #:style "emph" "custom style"))
+   '((span ((class "emph")) "custom style"))))


### PR DESCRIPTION
While adapting The Racket Guide to EPUB 3 for myself locally (reading using Apple Books), I noticed that Scribble renders `@emph`, `@superscript`, and `@subscript` as styled `<span>` elements.

Render them as `<em>`, `<sup>`, and `<sub>`. Keep `class="emph"` and the current subscript and superscript presentation. Add `line-height: inherit` to preserve the existing line-box behavior. Explicit `alt-tag` values, links, and custom string styles retain their current behavior.

This follows [PR #220](https://github.com/racket/scribble/pull/220), which made `@emph` logical and nestable. Its discussion proposed `<em>` output and [identified the HTML renderer as the implementation point](https://github.com/racket/scribble/pull/220#issuecomment-553451731). That PR already added Markdown support.