### PR TITLE
Fix bibtex parser to preserve spaces after nested braced strings

### DIFF
--- a/scribble-lib/scriblib/bibtex.rkt
+++ b/scribble-lib/scriblib/bibtex.rkt
@@ -138,7 +138,7 @@
                                      ip))
       (match (peek-char ip)
         [#\{
-         (string-append first-part (read-value ip) (loop))]
+         (string-append first-part (read-braced-value ip) (loop))]
         [#\}
          (read-char ip)
          first-part])))

--- a/scribble-test/tests/scriblib/test-braced-space.bib
+++ b/scribble-test/tests/scriblib/test-braced-space.bib
@@ -1,0 +1,16 @@
+@article{test-braced1,
+  title = {Advances in {ACM} Technology},
+  journal = {Proceedings of the {IEEE} Conference},
+  year = {2020}
+}
+
+@article{test-braced2,
+  title = {The {ACM} Framework},
+  year = {2021}
+}
+
+@inproceedings{test-braced3,
+  title = {Testing {SIGPLAN} Methods},
+  booktitle = {International {ACM} Conference},
+  year = {2022}
+}

--- a/scribble-test/tests/scriblib/test-braced-space.rkt
+++ b/scribble-test/tests/scriblib/test-braced-space.rkt
@@ -1,0 +1,21 @@
+#lang racket
+(require scriblib/bibtex
+         racket/runtime-path
+         rackunit)
+
+(define-runtime-path test.bib "test-braced-space.bib")
+
+(define db (path->bibdb test.bib))
+(define raw (bibdb-raw db))
+
+;; Test that spaces after braced strings are preserved
+(test-case "braced strings should preserve following spaces"
+  (define test1 (hash-ref raw "test-braced1"))
+  (define test2 (hash-ref raw "test-braced2"))
+  (define test3 (hash-ref raw "test-braced3"))
+
+  (check-equal? (hash-ref test1 "title") "Advances in ACM Technology")
+  (check-equal? (hash-ref test1 "journal") "Proceedings of the IEEE Conference")
+  (check-equal? (hash-ref test2 "title") "The ACM Framework")
+  (check-equal? (hash-ref test3 "title") "Testing SIGPLAN Methods")
+  (check-equal? (hash-ref test3 "booktitle") "International ACM Conference"))


### PR DESCRIPTION
The parser was incorrectly consuming whitespace following nested braced strings like {ACM}, causing "Advances in {ACM} Technology" to become "Advances in ACMTechnology". Changed read-braced-value to call itself recursively for nested braces instead of read-value, which consumes trailing whitespace.